### PR TITLE
[ISSUE #15747] Write cluster.conf atomically

### DIFF
--- a/specs/en/design/foundation-cluster-membership-spec.md
+++ b/specs/en/design/foundation-cluster-membership-spec.md
@@ -115,6 +115,10 @@ Change rules:
   full member-list change;
 - topology changes are written to `cluster.conf` for compatibility by
   `MemberUtil.syncToFile`;
+- compatibility persistence must write a complete member-list snapshot to a
+  temporary file in the same directory before replacing `cluster.conf`, using
+  an atomic move when the filesystem supports it; it must not truncate the
+  published file while constructing a new snapshot;
 - `MembersChangeEvent` is published only when the effective topology changes or
   basic member metadata changes.
 

--- a/specs/zh-cn/design/foundation-cluster-membership-spec.md
+++ b/specs/zh-cn/design/foundation-cluster-membership-spec.md
@@ -102,6 +102,8 @@ Lookup 选择规则：
 - 当同一地址仍然存在于新列表时，应保留已有 member 的元数据和能力；
 - `memberJoin` 和 `memberLeave` 是便捷操作，最终都解析为完整 member-list 变更；
 - topology 变化会通过 `MemberUtil.syncToFile` 写入 `cluster.conf` 以保持兼容；
+- 兼容落盘必须先在同一目录的临时文件中写完完整 member-list 快照，再替换 `cluster.conf`；文件系统支持时
+  必须使用原子移动，构造新快照期间不得截断已经发布的文件；
 - 只有有效 topology 变化或 member 基础元数据变化时，才发布 `MembersChangeEvent`。
 
 `ServerMemberManager.update(Member)` 用于更新已存在 member 的元数据/状态。它不得新增未知 member。

--- a/sys/src/main/java/com/alibaba/nacos/sys/env/EnvUtil.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/env/EnvUtil.java
@@ -21,7 +21,6 @@ import com.alibaba.nacos.common.utils.IoUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import com.alibaba.nacos.plugin.environment.CustomEnvironmentPluginManager;
-import com.alibaba.nacos.sys.utils.DiskUtils;
 import com.alibaba.nacos.sys.utils.InetUtils;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -31,7 +30,6 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -39,7 +37,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -409,9 +411,28 @@ public class EnvUtil {
         return instanceList;
     }
     
+    /**
+     * Write a complete cluster configuration snapshot without truncating the published file.
+     *
+     * @param content cluster configuration content
+     * @throws IOException if the temporary file cannot be written or published
+     */
     public static void writeClusterConf(String content) throws IOException {
-        DiskUtils.writeFile(new File(getClusterConfFilePath()),
-            content.getBytes(StandardCharsets.UTF_8), false);
+        Path clusterConfFile = Paths.get(getClusterConfFilePath());
+        Path temporaryFile = Files.createTempFile(clusterConfFile.getParent(),
+            clusterConfFile.getFileName().toString(), ".tmp");
+        try {
+            Files.write(temporaryFile, content.getBytes(StandardCharsets.UTF_8));
+            try {
+                Files.move(temporaryFile, clusterConfFile, StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporaryFile, clusterConfFile,
+                    StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporaryFile);
+        }
     }
     
     public static String getMemberList() {

--- a/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.sys.env;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import com.alibaba.nacos.plugin.environment.CustomEnvironmentPluginManager;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
-import com.alibaba.nacos.sys.utils.DiskUtils;
 import com.alibaba.nacos.sys.utils.InetUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -42,6 +41,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.management.OperatingSystemMXBean;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -360,11 +365,61 @@ class EnvUtilTest {
     
     @Test
     void testWriteClusterConf() throws IOException {
-        DiskUtils.forceMkdir(EnvUtil.getNacosHome() + "/conf");
-        EnvUtil.writeClusterConf("127.0.0.1");
-        File file = new File(EnvUtil.getNacosHome() + "/conf/cluster.conf");
-        assertTrue(file.exists());
-        assertEquals("127.0.0.1", FileUtils.readFileToString(file, "UTF-8"));
+        Path nacosHome = Files.createTempDirectory("nacos-cluster-conf");
+        try {
+            EnvUtil.setNacosHomePath(nacosHome.toString());
+            Path confDirectory = Files.createDirectories(nacosHome.resolve("conf"));
+            EnvUtil.writeClusterConf("127.0.0.1");
+            Path clusterConf = confDirectory.resolve("cluster.conf");
+            assertTrue(Files.exists(clusterConf));
+            assertEquals("127.0.0.1", Files.readString(clusterConf));
+            try (java.util.stream.Stream<Path> files = Files.list(confDirectory)) {
+                assertEquals(1L, files.count());
+            }
+        } finally {
+            EnvUtil.setNacosHomePath(null);
+            FileUtils.deleteDirectory(nacosHome.toFile());
+        }
+    }
+    
+    @Test
+    void testWriteClusterConfReplacesOpenPreviousVersion() throws IOException {
+        Path nacosHome = Files.createTempDirectory("nacos-cluster-conf");
+        try {
+            EnvUtil.setNacosHomePath(nacosHome.toString());
+            Path confDirectory = Files.createDirectories(nacosHome.resolve("conf"));
+            Path clusterConf = confDirectory.resolve("cluster.conf");
+            Files.writeString(clusterConf, "previous-content");
+            try (FileChannel previousVersion =
+                FileChannel.open(clusterConf, StandardOpenOption.WRITE)) {
+                EnvUtil.writeClusterConf("complete-new-content");
+                previousVersion.position(0L);
+                previousVersion.write(ByteBuffer.wrap(
+                    "concurrent-writer".getBytes(StandardCharsets.UTF_8)));
+            }
+            assertEquals("complete-new-content", Files.readString(clusterConf));
+        } finally {
+            EnvUtil.setNacosHomePath(null);
+            FileUtils.deleteDirectory(nacosHome.toFile());
+        }
+    }
+    
+    @Test
+    void testWriteClusterConfDeletesTemporaryFileAfterFailure() throws IOException {
+        Path nacosHome = Files.createTempDirectory("nacos-cluster-conf");
+        try {
+            EnvUtil.setNacosHomePath(nacosHome.toString());
+            Path confDirectory = Files.createDirectories(nacosHome.resolve("conf"));
+            Path clusterConf = Files.createDirectory(confDirectory.resolve("cluster.conf"));
+            Files.writeString(clusterConf.resolve("keep"), "content");
+            assertThrows(IOException.class, () -> EnvUtil.writeClusterConf("new-content"));
+            try (java.util.stream.Stream<Path> files = Files.list(confDirectory)) {
+                assertEquals(1L, files.count());
+            }
+        } finally {
+            EnvUtil.setNacosHomePath(null);
+            FileUtils.deleteDirectory(nacosHome.toFile());
+        }
     }
     
     @Test


### PR DESCRIPTION
Fixes #15747 
## What is the purpose of the change

This PR prevents Nacos from truncating the published `cluster.conf` while constructing a new cluster member snapshot.

Previously, `EnvUtil.writeClusterConf` wrote directly to `cluster.conf`. When an external writer such as Kubernetes peer-finder updated the same file concurrently, the writes could overlap and expose partial or interleaved content.

The Nacos-side write path now creates a complete snapshot in a temporary file located in the same directory and then replaces `cluster.conf`. It requests an atomic move when supported by the filesystem and falls back to a regular replacement otherwise.

## Brief changelog

- Write cluster member snapshots to a same-directory temporary file before publishing them.
- Use an atomic move when supported and clean up temporary files after success or failure.
- Add regression coverage for normal replacement, concurrent writes through an old file handle, and temporary-file cleanup after publication failure.
- Document the atomic publication requirement in the English and Chinese cluster membership specifications.

## Verifying this change

- `mvn -pl sys spotless:check`
- `mvn -pl sys -Dtest=EnvUtilTest test`
  - 41 tests passed with no failures or errors.
- `mvn -pl sys test`
  - All `sys` module tests passed.
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests`
  - All 62 Maven modules passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [[test module](https://github.com/alibaba/nacos/tree/master/test)](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.