### PR TITLE
[ISSUE #15724] Backport namespace propagation for listener IP query

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3.java
@@ -66,7 +66,7 @@ public class ListenerControllerV3 {
         @RequestParam(value = "namespaceId", required = false) String namespaceId,
         AggregationForm aggregationForm) {
         ConfigListenerInfo result = configListenerStateDelegate.getListenerStateByIp(ip,
-            aggregationForm.isAggregation());
+            namespaceId, aggregationForm.isAggregation());
         result.setQueryType(ConfigListenerInfo.QUERY_TYPE_IP);
         Map<String, String> configMd5Status = new HashMap<>(100);
         if (result.getListenersStatus() == null || result.getListenersStatus().isEmpty()) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateDelegate.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateDelegate.java
@@ -48,11 +48,12 @@ public class ConfigListenerStateDelegate {
         return result;
     }
     
-    public ConfigListenerInfo getListenerStateByIp(String ip, boolean aggregation) {
-        ConfigListenerInfo result = localService.getListenerStateByIp(ip);
+    public ConfigListenerInfo getListenerStateByIp(String ip, String namespaceId,
+        boolean aggregation) {
+        ConfigListenerInfo result = localService.getListenerStateByIp(ip, namespaceId);
         if (aggregation) {
             result.getListenersStatus()
-                .putAll(remoteService.getListenerStateByIp(ip).getListenersStatus());
+                .putAll(remoteService.getListenerStateByIp(ip, namespaceId).getListenersStatus());
         }
         return result;
     }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateService.java
@@ -38,8 +38,9 @@ public interface ConfigListenerStateService {
     /**
      * Get config listener state by listener ip.
      *
-     * @param ip    listener ip
+     * @param ip            listener ip
+     * @param namespaceId   namespace id of config
      * @return      listener config information, include dataId, groupName, namespaceId and config md5
      */
-    ConfigListenerInfo getListenerStateByIp(String ip);
+    ConfigListenerInfo getListenerStateByIp(String ip, String namespaceId);
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/listener/LocalConfigListenerStateServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/listener/LocalConfigListenerStateServiceImpl.java
@@ -79,7 +79,7 @@ public class LocalConfigListenerStateServiceImpl implements ConfigListenerStateS
     }
     
     @Override
-    public ConfigListenerInfo getListenerStateByIp(String ip) {
+    public ConfigListenerInfo getListenerStateByIp(String ip, String namespaceId) {
         // long polling listeners for 1.x client TODO removed after 3.x not support 1.x client.
         SampleResult result = longPollingService.getCollectSubscribleInfoByIp(ip);
         // rpc listeners for upper 2.x client.

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/listener/RemoteConfigListenerStateServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/listener/RemoteConfigListenerStateServiceImpl.java
@@ -81,8 +81,9 @@ public class RemoteConfigListenerStateServiceImpl implements ConfigListenerState
     }
     
     @Override
-    public ConfigListenerInfo getListenerStateByIp(String ip) {
-        Query query = Query.newInstance().addParam("ip", ip).addParam("aggregation", false);
+    public ConfigListenerInfo getListenerStateByIp(String ip, String namespaceId) {
+        Query query = Query.newInstance().addParam("ip", ip).addParam("namespaceId", namespaceId)
+            .addParam("aggregation", false);
         Header header = buildHeader();
         ConfigListenerInfo result = new ConfigListenerInfo();
         result.setListenersStatus(new HashMap<>(16));

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3Test.java
@@ -76,7 +76,7 @@ class ListenerControllerV3Test {
         Map<String, String> map = new HashMap<>();
         map.put("test", "test");
         sampleResult.setListenersStatus(map);
-        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", "test", true))
             .thenReturn(sampleResult);
         
         MockHttpServletRequestBuilder builder =
@@ -98,7 +98,7 @@ class ListenerControllerV3Test {
     @Test
     void testGetAllSubClientConfigByIpEmptyListeners() throws Exception {
         ConfigListenerInfo sampleResult = new ConfigListenerInfo();
-        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", null, true))
             .thenReturn(sampleResult);
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)
@@ -115,7 +115,7 @@ class ListenerControllerV3Test {
         map.put("dataId+group+ns1", "md5a");
         map.put("dataId+group+ns2", "md5b");
         sampleResult.setListenersStatus(map);
-        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", "ns1", true))
             .thenReturn(sampleResult);
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)
@@ -132,7 +132,7 @@ class ListenerControllerV3Test {
         Map<String, String> map = new HashMap<>();
         map.put("dataId+group+tenant", "md5");
         sampleResult.setListenersStatus(map);
-        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", null, true))
             .thenReturn(sampleResult);
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)
@@ -153,7 +153,7 @@ class ListenerControllerV3Test {
         Map<String, String> map = new HashMap<>();
         map.put("dataId+group", "md5");
         sampleResult.setListenersStatus(map);
-        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", null, true))
             .thenReturn(sampleResult);
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateDelegateTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/listener/ConfigListenerStateDelegateTest.java
@@ -78,10 +78,10 @@ class ConfigListenerStateDelegateTest {
     void testGetListenerStateByIpWithoutAggregation() {
         ConfigListenerInfo localInfo = new ConfigListenerInfo();
         localInfo.setListenersStatus(new HashMap<>());
-        when(localService.getListenerStateByIp("1.2.3.4"))
+        when(localService.getListenerStateByIp("1.2.3.4", "ns"))
             .thenReturn(localInfo);
         ConfigListenerInfo result =
-            delegate.getListenerStateByIp("1.2.3.4", false);
+            delegate.getListenerStateByIp("1.2.3.4", "ns", false);
         assertNotNull(result);
         verifyNoInteractions(remoteService);
     }
@@ -92,13 +92,13 @@ class ConfigListenerStateDelegateTest {
         localInfo.setListenersStatus(new HashMap<>());
         ConfigListenerInfo remoteInfo = new ConfigListenerInfo();
         remoteInfo.setListenersStatus(new HashMap<>());
-        when(localService.getListenerStateByIp("1.2.3.4"))
+        when(localService.getListenerStateByIp("1.2.3.4", "ns"))
             .thenReturn(localInfo);
-        when(remoteService.getListenerStateByIp("1.2.3.4"))
+        when(remoteService.getListenerStateByIp("1.2.3.4", "ns"))
             .thenReturn(remoteInfo);
         ConfigListenerInfo result =
-            delegate.getListenerStateByIp("1.2.3.4", true);
+            delegate.getListenerStateByIp("1.2.3.4", "ns", true);
         assertNotNull(result);
-        verify(remoteService).getListenerStateByIp("1.2.3.4");
+        verify(remoteService).getListenerStateByIp("1.2.3.4", "ns");
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/listener/LocalConfigListenerStateServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/listener/LocalConfigListenerStateServiceImplTest.java
@@ -160,7 +160,7 @@ class LocalConfigListenerStateServiceImplTest {
         when(configChangeListenContext.getListenKeys("conn-1"))
             .thenReturn(listenKeys);
         
-        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4");
+        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4", "ns");
         assertNotNull(result);
         assertEquals(ConfigListenerInfo.QUERY_TYPE_IP, result.getQueryType());
         assertEquals("md5-1", result.getListenersStatus().get("gk1"));
@@ -181,7 +181,7 @@ class LocalConfigListenerStateServiceImplTest {
         when(configChangeListenContext.getListenKeys("conn-1"))
             .thenReturn(null);
         
-        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4");
+        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4", "ns");
         assertNotNull(result);
         assertEquals(0, result.getListenersStatus().size());
     }
@@ -195,7 +195,7 @@ class LocalConfigListenerStateServiceImplTest {
         when(connectionManager.getConnectionByIp("1.2.3.4"))
             .thenReturn(Collections.emptyList());
         
-        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4");
+        ConfigListenerInfo result = service.getListenerStateByIp("1.2.3.4", "ns");
         assertNotNull(result);
         assertEquals(0, result.getListenersStatus().size());
     }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/listener/RemoteConfigListenerStateServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/listener/RemoteConfigListenerStateServiceImplTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.service.notify.HttpClientManager;
 import com.alibaba.nacos.core.cluster.Member;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -181,7 +183,7 @@ class RemoteConfigListenerStateServiceImplTest {
         when(memberManager.allMembersWithoutSelf())
             .thenReturn(Collections.emptyList());
         ConfigListenerInfo result =
-            service.getListenerStateByIp("1.2.3.4");
+            service.getListenerStateByIp("1.2.3.4", "ns");
         assertNotNull(result);
         assertEquals(ConfigListenerInfo.QUERY_TYPE_IP,
             result.getQueryType());
@@ -208,8 +210,33 @@ class RemoteConfigListenerStateServiceImplTest {
             .get(anyString(), any(), any(), eq(String.class));
         
         ConfigListenerInfo result =
-            service.getListenerStateByIp("1.2.3.4");
+            service.getListenerStateByIp("1.2.3.4", "ns");
         assertNotNull(result);
         assertEquals("md5val", result.getListenersStatus().get("gk1"));
+    }
+    
+    @Test
+    void testGetListenerStateByIpPassesNamespaceIdToRemoteQuery() throws Exception {
+        Member member = new Member();
+        member.setIp("10.0.0.1");
+        member.setPort(8848);
+        List<Member> members = new ArrayList<>();
+        members.add(member);
+        when(memberManager.allMembersWithoutSelf()).thenReturn(members);
+        
+        ConfigListenerInfo info = new ConfigListenerInfo();
+        info.setListenersStatus(new HashMap<>());
+        Result<ConfigListenerInfo> apiResult = Result.success(info);
+        String json = JacksonUtils.toJson(apiResult);
+        HttpRestResult<String> restResult = new HttpRestResult<>();
+        restResult.setCode(200);
+        restResult.setData(json);
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        doReturn(restResult).when(nacosRestTemplate)
+            .get(anyString(), any(), queryCaptor.capture(), eq(String.class));
+        
+        service.getListenerStateByIp("1.2.3.4", "ns1");
+        
+        assertEquals("ns1", queryCaptor.getValue().getValue("namespaceId"));
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandler.java
@@ -242,7 +242,7 @@ public class ConfigInnerHandler implements ConfigHandler {
     public ConfigListenerInfo getAllSubClientConfigByIp(String ip, boolean all, String namespaceId,
         boolean aggregation) {
         ConfigListenerInfo result =
-            configListenerStateDelegate.getListenerStateByIp(ip, aggregation);
+            configListenerStateDelegate.getListenerStateByIp(ip, namespaceId, aggregation);
         result.setQueryType(ConfigListenerInfo.QUERY_TYPE_IP);
         Map<String, String> configMd5Status = new HashMap<>(100);
         if (result.getListenersStatus() == null || result.getListenersStatus().isEmpty()) {

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandlerTest.java
@@ -279,7 +279,8 @@ class ConfigInnerHandlerTest {
     @Test
     void getAllSubClientConfigByIpEmpty() {
         ConfigListenerInfo mock = new ConfigListenerInfo();
-        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", true)).thenReturn(mock);
+        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", "tenant", true))
+            .thenReturn(mock);
         assertEquals(mock,
             configInnerHandler.getAllSubClientConfigByIp("127.0.0.1", true, "tenant", true));
     }
@@ -291,7 +292,8 @@ class ConfigInnerHandlerTest {
         configMd5Status.put("dataId+group+tenant", "1");
         configMd5Status.put("dataId+group+aaa", "2");
         mock.setListenersStatus(configMd5Status);
-        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", false)).thenReturn(mock);
+        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", "tenant", false))
+            .thenReturn(mock);
         ConfigListenerInfo actual =
             configInnerHandler.getAllSubClientConfigByIp("127.0.0.1", true, "tenant", false);
         assertEquals(ConfigListenerInfo.QUERY_TYPE_IP, actual.getQueryType());
@@ -307,7 +309,8 @@ class ConfigInnerHandlerTest {
         configMd5Status.put("dataId+group", "1");
         configMd5Status.put("dataId+group+aaa", "2");
         mock.setListenersStatus(configMd5Status);
-        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", false)).thenReturn(mock);
+        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", "", false))
+            .thenReturn(mock);
         ConfigListenerInfo actual =
             configInnerHandler.getAllSubClientConfigByIp("127.0.0.1", false, "", false);
         assertEquals(ConfigListenerInfo.QUERY_TYPE_IP, actual.getQueryType());
@@ -323,7 +326,8 @@ class ConfigInnerHandlerTest {
         configMd5Status.put("dataId+group+aaa", "2");
         configMd5Status.put("dataId+group+tenant", "3");
         mock.setListenersStatus(configMd5Status);
-        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", false)).thenReturn(mock);
+        when(configListenerStateDelegate.getListenerStateByIp("127.0.0.1", "aaa", false))
+            .thenReturn(mock);
         ConfigListenerInfo actual =
             configInnerHandler.getAllSubClientConfigByIp("127.0.0.1", false, "aaa", false);
         assertEquals(ConfigListenerInfo.QUERY_TYPE_IP, actual.getQueryType());


### PR DESCRIPTION
## What is the purpose of the change

Backport #15732 to `v3.2.4-develop` so listener state aggregation by client IP preserves the namespace filter when querying remote cluster members.

For #15724

## Brief changelog

- Propagate `namespaceId` through the listener state controller, delegate, and service interfaces.
- Include `namespaceId` in remote listener-by-IP queries.
- Update unit tests for the affected config and console call paths.

## Verifying this change

- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
- 57 affected config and console unit tests passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run the repository CI-equivalent compile, RAT, Checkstyle, SpotBugs, and Spotless checks locally.
