### PR TITLE
[ISSUE #15763] Reject IPv6 mixed addresses with more than six 16-bit blocks

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -36,6 +36,12 @@ public class InetAddressValidator {
     
     private static final int FIVE = 5;
     
+    /**
+     * In the IPv6 mixed notation the IPv6 part holds at most 96 bits, that is six 16-bit blocks,
+     * because the trailing IPv4 part occupies the remaining 32 bits.
+     */
+    private static final int MAX_MIXED_IPV6_BLOCKS = 6;
+    
     private static final Pattern IPV4_PATTERN = Pattern
         .compile("^" + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)"
             + "(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}" + "$");
@@ -129,7 +135,31 @@ public class InetAddressValidator {
             IPV6_MIXED_UNCOMPRESSED_REGEX.matcher(ipV6Part).matches();
         boolean ipV6CompressedDetected = IPV6_MIXED_COMPRESSED_REGEX.matcher(ipV6Part).matches();
         
-        return ipv4PartValid && (ipV6UncompressedDetected || ipV6CompressedDetected);
+        return ipv4PartValid && (ipV6UncompressedDetected || ipV6CompressedDetected)
+            && countHexBlocks(ipV6Part) <= MAX_MIXED_IPV6_BLOCKS;
+    }
+    
+    /**
+     * Count the non-empty 16-bit blocks in the IPv6 part of a mixed address.
+     *
+     * @param ipV6Part the IPv6 part of a mixed address, including the trailing colon
+     * @return the number of non-empty blocks
+     */
+    private static int countHexBlocks(final String ipV6Part) {
+        int count = 0;
+        int index = 0;
+        int length = ipV6Part.length();
+        while (index < length) {
+            if (ipV6Part.charAt(index) == ':') {
+                index++;
+                continue;
+            }
+            count++;
+            while (index < length && ipV6Part.charAt(index) != ':') {
+                index++;
+            }
+        }
+        return count;
     }
     
     /**

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InetAddressValidatorTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InetAddressValidatorTest.java
@@ -46,6 +46,17 @@ class InetAddressValidatorTest {
     }
     
     @Test
+    void isIpv6MixedAddressRejectsTooManyBlocks() {
+        // The IPv6 part of a mixed address holds at most six 16-bit blocks, because the
+        // trailing IPv4 part occupies the remaining 32 bits of the 128-bit address.
+        assertTrue(InetAddressValidator.isIpv6MixedAddress("::1:2:3:4:5:172.12.55.18"));
+        assertTrue(InetAddressValidator.isIpv6MixedAddress("1:2:3::4:5:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("::1:2:3:4:5:6:7:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("::1:2:3:4:5:6:7:8:9:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6Address("::1:2:3:4:5:6:7:8:9:172.12.55.18"));
+    }
+    
+    @Test
     void isIpv6Ipv4MappedAddress() {
         assertFalse(InetAddressValidator.isIpv6Ipv4MappedAddress(":ffff:1.1.1.1"));
         assertTrue(InetAddressValidator.isIpv6Ipv4MappedAddress("::FFFF:192.168.1.2"));


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15763.

`isIpv6MixedAddress` accepted IPv6 mixed addresses whose IPv6 part contains more
than six 16-bit blocks, so addresses longer than 128 bits were reported as valid
IPv6 addresses.

## Brief changelog

- `InetAddressValidator.isIpv6MixedAddress`: reject the address when the IPv6
  part holds more than `MAX_MIXED_IPV6_BLOCKS` (6) blocks.
- Add `countHexBlocks` helper.
- `InetAddressValidatorTest`: add `isIpv6MixedAddressRejectsTooManyBlocks`.

The regexes are left unchanged. I first tried bounding the quantifiers in
`IPV6_MIXED_COMPRESSED_REGEX` to `{0,5}`, but that rejected the valid
`::1:2:3:4:5:6:` form, so the block count is checked in the method instead.

## Verifying this change

- `isIpv6MixedAddressRejectsTooManyBlocks` fails before this change
  (`expected: <false> but was: <true>`) and passes after it.
- `mvn -pl common -am test`: 955 tests, 0 failures.
- `mvn -pl common -am checkstyle:check`: BUILD SUCCESS.
- Cross-checked all cases against `java.net.InetAddress.getByName`, which
  rejects the same three addresses.

The uncompressed branch (`IPV6_MIXED_UNCOMPRESSED_REGEX`) is already bounded to
six blocks and is unaffected. Valid forms such as `0:0:0:0:0:0:172.12.55.18`,
`::172.12.55.18`, `::1:2:3:4:5:172.12.55.18` and `1:2:3::4:5:172.12.55.18`
still pass.
