### PR TITLE
[ISSUE #15763] Limit compressed IPv6 mixed addresses to five explicit blocks

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -42,6 +42,12 @@ public class InetAddressValidator {
      */
     private static final int MAX_MIXED_IPV6_BLOCKS = 6;
     
+    /**
+     * A compressed IPv6 part may hold at most five explicit blocks, because "::" stands for at
+     * least one omitted 16-bit block.
+     */
+    private static final int MAX_COMPRESSED_MIXED_IPV6_BLOCKS = MAX_MIXED_IPV6_BLOCKS - 1;
+    
     private static final Pattern IPV4_PATTERN = Pattern
         .compile("^" + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)"
             + "(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}" + "$");
@@ -135,8 +141,9 @@ public class InetAddressValidator {
             IPV6_MIXED_UNCOMPRESSED_REGEX.matcher(ipV6Part).matches();
         boolean ipV6CompressedDetected = IPV6_MIXED_COMPRESSED_REGEX.matcher(ipV6Part).matches();
         
-        return ipv4PartValid && (ipV6UncompressedDetected || ipV6CompressedDetected)
-            && countHexBlocks(ipV6Part) <= MAX_MIXED_IPV6_BLOCKS;
+        return ipv4PartValid && (ipV6UncompressedDetected
+            || (ipV6CompressedDetected
+                && countHexBlocks(ipV6Part) <= MAX_COMPRESSED_MIXED_IPV6_BLOCKS));
     }
     
     /**

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InetAddressValidatorTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InetAddressValidatorTest.java
@@ -57,6 +57,22 @@ class InetAddressValidatorTest {
     }
     
     @Test
+    void isIpv6MixedAddressBlockLimitDependsOnCompression() {
+        // Without "::" all six blocks are written explicitly.
+        assertTrue(InetAddressValidator.isIpv6MixedAddress("1:2:3:4:5:6:172.12.55.18"));
+        // "::" stands for at least one omitted block, so a compressed IPv6 part carries at
+        // most five explicit blocks, wherever "::" appears.
+        assertTrue(InetAddressValidator.isIpv6MixedAddress("::1:2:3:4:5:172.12.55.18"));
+        assertTrue(InetAddressValidator.isIpv6MixedAddress("1:2:3:4:5::172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("::1:2:3:4:5:6:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("1:2:3:4:5:6::172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("1::1:2:3:4:5:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("1:2:3::1:2:3:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6MixedAddress("1:2:3:4:5::1:172.12.55.18"));
+        assertFalse(InetAddressValidator.isIpv6Address("::1:2:3:4:5:6:172.12.55.18"));
+    }
+    
+    @Test
     void isIpv6Ipv4MappedAddress() {
         assertFalse(InetAddressValidator.isIpv6Ipv4MappedAddress(":ffff:1.1.1.1"));
         assertTrue(InetAddressValidator.isIpv6Ipv4MappedAddress("::FFFF:192.168.1.2"));


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15763. Follow-up to #15764, addressing the remaining boundary case raised
in review.

#15764 bounded the IPv6 part of a mixed address to six blocks. That is correct
for the uncompressed form, but a compressed IPv6 part may carry at most five
explicit blocks, because `::` stands for at least one omitted 16-bit block.
`::1:2:3:4:5:6:172.12.55.18` was therefore still accepted.

## Brief changelog

- Apply the six-block limit only to the uncompressed form, which
  `IPV6_MIXED_UNCOMPRESSED_REGEX` already enforces, and limit a compressed IPv6
  part to `MAX_COMPRESSED_MIXED_IPV6_BLOCKS` (5) explicit blocks.
- `InetAddressValidatorTest`: add `isIpv6MixedAddressBlockLimitDependsOnCompression`.

This also covers the same case with `::` in any position, since the root cause is
the total block count rather than where `::` appears. Generating 102 inputs by
varying the block count and the position of `::` and comparing the result with
`java.net.InetAddress`, the current `develop` accepts seven invalid addresses:

```
::1:2:3:4:5:6:172.12.55.18
1:2:3:4:5:6::172.12.55.18
1::1:2:3:4:5:172.12.55.18
1:2::1:2:3:4:172.12.55.18
1:2:3::1:2:3:172.12.55.18
1:2:3:4::1:2:172.12.55.18
1:2:3:4:5::1:172.12.55.18
```

After this change all 102 inputs agree with the JDK, with no address newly
rejected.

For the record, my note in #15764 about `{0,5}` causing a regression was wrong:
`::1:2:3:4:5:6:` is genuinely invalid, so rejecting it was the correct behaviour
and I had compared it against a wrong expectation. Checking the block count in
the method still seems clearer than encoding it in the regex, but the reasoning I
gave for it was not.

## Verifying this change

- `isIpv6MixedAddressBlockLimitDependsOnCompression` fails before this change
  (`expected: <false> but was: <true>`) and passes after it.
- `mvn -pl common -am test`: 956 tests, 0 failures.
- `mvn -B clean compile apache-rat:check checkstyle:check spotless:check -DskipTests`:
  BUILD SUCCESS.
- Cross-checked the 102 generated inputs against `java.net.InetAddress.getByName`.

Valid forms still pass: `1:2:3:4:5:6:172.12.55.18` (six explicit, uncompressed),
`0:0:0:0:0:0:172.12.55.18`, `::172.12.55.18`, `::1:2:3:4:5:172.12.55.18`,
`1:2:3:4:5::172.12.55.18` and `1:2:3::4:5:172.12.55.18`.
