### PR TITLE
[ISSUE #15761] Add MCP AI resource mapping and storage foundation

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/model/mcp/McpResourceExt.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/model/mcp/McpResourceExt.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.mcp;
+
+/**
+ * Typed schema-versioned content stored in {@code ai_resource.ext} for MCP.
+ *
+ * @author Nacos
+ */
+public class McpResourceExt {
+    
+    public static final int SCHEMA_VERSION = 1;
+    
+    private Integer schemaVersion;
+    
+    private String mcpId;
+    
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
+    
+    public void setSchemaVersion(Integer schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+    
+    public String getMcpId() {
+        return mcpId;
+    }
+    
+    public void setMcpId(String mcpId) {
+        this.mcpId = mcpId;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/model/mcp/McpVersionStorageDescriptor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/model/mcp/McpVersionStorageDescriptor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.mcp;
+
+/**
+ * Storage descriptor persisted in one MCP Version row.
+ *
+ * @author Nacos
+ */
+public class McpVersionStorageDescriptor {
+    
+    public static final String PROVIDER = "nacos_config";
+    
+    public static final String KEY_FORMAT = "mcp-config-v1";
+    
+    public static final int SCHEMA_VERSION = 1;
+    
+    private String provider;
+    
+    private String keyFormat;
+    
+    private String serverKey;
+    
+    private String toolKey;
+    
+    private String resourceKey;
+    
+    private Integer schemaVersion;
+    
+    public String getProvider() {
+        return provider;
+    }
+    
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+    
+    public String getKeyFormat() {
+        return keyFormat;
+    }
+    
+    public void setKeyFormat(String keyFormat) {
+        this.keyFormat = keyFormat;
+    }
+    
+    public String getServerKey() {
+        return serverKey;
+    }
+    
+    public void setServerKey(String serverKey) {
+        this.serverKey = serverKey;
+    }
+    
+    public String getToolKey() {
+        return toolKey;
+    }
+    
+    public void setToolKey(String toolKey) {
+        this.toolKey = toolKey;
+    }
+    
+    public String getResourceKey() {
+        return resourceKey;
+    }
+    
+    public void setResourceKey(String resourceKey) {
+        this.resourceKey = resourceKey;
+    }
+    
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
+    
+    public void setSchemaVersion(Integer schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocator.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.ai.service.mcp.storage.McpResourceExtSerializer;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Resolves canonical MCP Resources from a name and the deprecated MCP compatibility alias.
+ *
+ * <p>This resolver queries only {@code ai_resource}. It never falls back to Search, serving
+ * Manifest, Config, or the historical MCP in-memory index.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class McpResourceLocator {
+    
+    private static final int ID_SCAN_PAGE_SIZE = 100;
+    
+    private static final String RESOURCE_NAME_FIELD = "name";
+    
+    private final AiResourcePersistService resourcePersistService;
+    
+    public McpResourceLocator(AiResourcePersistService resourcePersistService) {
+        this.resourcePersistService = resourcePersistService;
+    }
+    
+    /**
+     * Resolve exactly one canonical MCP Resource.
+     *
+     * @param namespaceId namespace identifier; blank uses the MCP default namespace
+     * @param mcpName canonical MCP name, optional only for a legacy ID-only request
+     * @param mcpId deprecated MCP compatibility alias, optional when name is present
+     * @return the uniquely resolved MCP Resource row
+     * @throws NacosApiException for invalid input, missing resources, or stored identity conflicts
+     */
+    public AiResource locate(String namespaceId, String mcpName, String mcpId)
+        throws NacosApiException {
+        String normalizedNamespace = normalizeNamespace(namespaceId);
+        boolean hasName = StringUtils.isNotBlank(mcpName);
+        boolean hasId = StringUtils.isNotBlank(mcpId);
+        if (!hasName && !hasId) {
+            throw invalidParameter("Either mcpName or mcpId must be provided", null);
+        }
+        if (hasId) {
+            validateInputMcpId(mcpId);
+        }
+        if (hasName) {
+            AiResource resource = findUniqueByName(normalizedNamespace, mcpName);
+            McpResourceExt resourceExt = requireResourceExt(resource);
+            if (hasId && !mcpId.equals(resourceExt.getMcpId())) {
+                throw invalidParameter("mcpName and mcpId identify different MCP resources", null);
+            }
+            return resource;
+        }
+        return findUniqueById(normalizedNamespace, mcpId);
+    }
+    
+    private AiResource findUniqueByName(String namespaceId, String mcpName)
+        throws NacosApiException {
+        QueryCondition condition = baseCondition(namespaceId);
+        condition.putOrGroup(RESOURCE_NAME_FIELD, mcpName);
+        Page<AiResource> page = resourcePersistService.list(condition, 1, 2);
+        List<AiResource> items = page == null ? null : page.getPageItems();
+        if (page == null || CollectionUtils.isEmpty(items)) {
+            throw notFound(namespaceId, mcpName, null);
+        }
+        if (page.getTotalCount() > 1 || items.size() > 1) {
+            throw integrityFailure("Multiple MCP Resource rows exist for name " + mcpName, null);
+        }
+        AiResource result = items.get(0);
+        validateReturnedRow(result, namespaceId, mcpName);
+        return result;
+    }
+    
+    private AiResource findUniqueById(String namespaceId, String mcpId)
+        throws NacosApiException {
+        int pageNumber = 1;
+        int pagesAvailable = 1;
+        AiResource match = null;
+        while (pageNumber <= pagesAvailable) {
+            Page<AiResource> page = resourcePersistService.list(baseCondition(namespaceId),
+                pageNumber, ID_SCAN_PAGE_SIZE);
+            if (page == null || page.getPageItems() == null) {
+                throw integrityFailure("Unable to page MCP Resource rows for legacy ID lookup",
+                    null);
+            }
+            pagesAvailable = resolvePagesAvailable(page, pageNumber);
+            for (AiResource resource : page.getPageItems()) {
+                validateReturnedRow(resource, namespaceId, null);
+                McpResourceExt resourceExt = requireResourceExt(resource);
+                if (mcpId.equals(resourceExt.getMcpId())) {
+                    if (match != null) {
+                        throw integrityFailure(
+                            "Multiple MCP Resource rows use compatibility mcpId " + mcpId, null);
+                    }
+                    match = resource;
+                }
+            }
+            pageNumber++;
+        }
+        if (match == null) {
+            throw notFound(namespaceId, null, mcpId);
+        }
+        return match;
+    }
+    
+    private int resolvePagesAvailable(Page<AiResource> page, int pageNumber) {
+        if (page.getPagesAvailable() > 0) {
+            return Math.max(pageNumber, page.getPagesAvailable());
+        }
+        int calculated = (page.getTotalCount() + ID_SCAN_PAGE_SIZE - 1) / ID_SCAN_PAGE_SIZE;
+        return Math.max(pageNumber, calculated);
+    }
+    
+    private McpResourceExt requireResourceExt(AiResource resource) throws NacosApiException {
+        try {
+            return McpResourceExtSerializer.deserialize(resource.getExt());
+        } catch (IllegalArgumentException e) {
+            throw integrityFailure(
+                "MCP Resource " + resource.getName() + " has invalid compatibility identity", e);
+        }
+    }
+    
+    private void validateReturnedRow(AiResource resource, String namespaceId, String mcpName)
+        throws NacosApiException {
+        boolean valid = resource != null
+            && namespaceId.equals(resource.getNamespaceId())
+            && AiResourceConstants.RESOURCE_TYPE_MCP.equals(resource.getType())
+            && (mcpName == null || mcpName.equals(resource.getName()));
+        if (!valid) {
+            throw integrityFailure("MCP Resource query returned an inconsistent row", null);
+        }
+    }
+    
+    private QueryCondition baseCondition(String namespaceId) {
+        QueryCondition result = new QueryCondition();
+        result.setNamespaceId(namespaceId);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        return result;
+    }
+    
+    private String normalizeNamespace(String namespaceId) throws NacosApiException {
+        String result = StringUtils.isBlank(namespaceId)
+            ? AiConstants.Mcp.MCP_DEFAULT_NAMESPACE : namespaceId;
+        try {
+            AgentValidationUtils.validateNamespaceId(result);
+        } catch (IllegalArgumentException e) {
+            throw invalidParameter("Invalid MCP namespaceId: " + namespaceId, e);
+        }
+        return result;
+    }
+    
+    private void validateInputMcpId(String mcpId) throws NacosApiException {
+        try {
+            McpResourceExtSerializer.validateMcpId(mcpId);
+        } catch (IllegalArgumentException e) {
+            throw invalidParameter("Invalid MCP compatibility mcpId", e);
+        }
+    }
+    
+    private NacosApiException invalidParameter(String message, Throwable cause) {
+        return cause == null
+            ? new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, message)
+            : new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, cause, message);
+    }
+    
+    private NacosApiException notFound(String namespaceId, String mcpName, String mcpId) {
+        String identity = mcpName == null ? "mcpId=" + mcpId : "mcpName=" + mcpName;
+        return new NacosApiException(NacosException.NOT_FOUND, ErrorCode.MCP_SERVER_NOT_FOUND,
+            "MCP Resource not found in namespace " + namespaceId + ": " + identity);
+    }
+    
+    private NacosApiException integrityFailure(String message, Throwable cause) {
+        return cause == null
+            ? new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT, message)
+            : new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT, cause,
+                message);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupport.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupport.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared strict JSON shape validation for MCP internal storage contracts.
+ *
+ * @author Nacos
+ */
+final class McpJsonValidationSupport {
+    
+    private static final JsonFactory STRICT_JSON_FACTORY = new JsonFactory()
+        .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    
+    private McpJsonValidationSupport() {
+    }
+    
+    static Object parseSingleValue(String json, String contractName) {
+        if (json == null || json.trim().isEmpty()) {
+            throw new IllegalArgumentException(contractName + " JSON must not be empty");
+        }
+        validateSingleJsonValue(json, contractName);
+        try {
+            return JacksonUtils.toObj(json, Object.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException("Invalid " + contractName, e);
+        }
+    }
+    
+    static Map<?, ?> parseObject(String json, String contractName) {
+        Object value = parseSingleValue(json, contractName);
+        if (!(value instanceof Map)) {
+            throw new IllegalArgumentException(contractName + " must be a JSON object");
+        }
+        return (Map<?, ?>) value;
+    }
+    
+    static void rejectUnknownFields(Map<?, ?> object, Set<String> fields, String contractName) {
+        for (Object field : object.keySet()) {
+            if (!(field instanceof String) || !fields.contains(field)) {
+                throw new IllegalArgumentException("Unknown " + contractName + " field: " + field);
+            }
+        }
+    }
+    
+    static String requireText(Map<?, ?> object, String field, String contractName) {
+        Object value = object.get(field);
+        if (!(value instanceof String)) {
+            throw new IllegalArgumentException(contractName + " " + field + " must be a string");
+        }
+        return (String) value;
+    }
+    
+    static String optionalText(Map<?, ?> object, String field, String contractName) {
+        if (!object.containsKey(field)) {
+            return null;
+        }
+        return requireText(object, field, contractName);
+    }
+    
+    static int requireInteger(Map<?, ?> object, String field, String contractName) {
+        Object value = object.get(field);
+        if (!(value instanceof Byte || value instanceof Short || value instanceof Integer
+            || value instanceof Long)) {
+            throw new IllegalArgumentException(contractName + " " + field + " must be an integer");
+        }
+        long result = ((Number) value).longValue();
+        if (result < Integer.MIN_VALUE || result > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(contractName + " " + field + " is out of range");
+        }
+        return (int) result;
+    }
+    
+    private static void validateSingleJsonValue(String json, String contractName) {
+        try (JsonParser parser = STRICT_JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() == null) {
+                throw new IllegalArgumentException(contractName + " JSON must not be empty");
+            }
+            parser.skipChildren();
+            if (parser.nextToken() != null) {
+                throw new IllegalArgumentException(contractName + " must contain one JSON value");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid " + contractName, e);
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Strict JSON serializer for the MCP content persisted in {@code ai_resource.ext}.
+ *
+ * @author Nacos
+ */
+public final class McpResourceExtSerializer {
+    
+    private static final Pattern MCP_ID_PATTERN = Pattern.compile(
+        "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}");
+    
+    private static final Set<String> FIELDS = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList("schemaVersion", "mcpId")));
+    
+    private McpResourceExtSerializer() {
+    }
+    
+    /**
+     * Validate and serialize one MCP Resource extension.
+     *
+     * @param resourceExt extension object
+     * @return canonical JSON stored in {@code ai_resource.ext}
+     */
+    public static String serialize(McpResourceExt resourceExt) {
+        validate(resourceExt);
+        Map<String, Object> projection = new LinkedHashMap<String, Object>();
+        projection.put("schemaVersion", McpResourceExt.SCHEMA_VERSION);
+        projection.put("mcpId", resourceExt.getMcpId());
+        try {
+            return JacksonUtils.toJson(projection);
+        } catch (NacosSerializationException e) {
+            throw new IllegalArgumentException("Unable to serialize McpResourceExt", e);
+        }
+    }
+    
+    /**
+     * Deserialize and strictly validate one MCP Resource extension.
+     *
+     * @param json persisted JSON
+     * @return validated extension object
+     */
+    public static McpResourceExt deserialize(String json) {
+        Map<?, ?> root = McpJsonValidationSupport.parseObject(json, "McpResourceExt");
+        McpJsonValidationSupport.rejectUnknownFields(root, FIELDS, "McpResourceExt");
+        McpResourceExt result = new McpResourceExt();
+        result.setSchemaVersion(McpJsonValidationSupport.requireInteger(root, "schemaVersion",
+            "McpResourceExt"));
+        result.setMcpId(McpJsonValidationSupport.requireText(root, "mcpId", "McpResourceExt"));
+        validate(result);
+        return result;
+    }
+    
+    /**
+     * Validate one MCP Resource extension against schema version 1.
+     *
+     * @param resourceExt extension object
+     */
+    public static void validate(McpResourceExt resourceExt) {
+        if (resourceExt == null) {
+            throw new IllegalArgumentException("McpResourceExt must not be null");
+        }
+        if (!Integer.valueOf(McpResourceExt.SCHEMA_VERSION)
+            .equals(resourceExt.getSchemaVersion())) {
+            throw new IllegalArgumentException("McpResourceExt schemaVersion must be "
+                + McpResourceExt.SCHEMA_VERSION);
+        }
+        validateMcpId(resourceExt.getMcpId());
+    }
+    
+    /**
+     * Validate the UUID-shaped MCP compatibility alias.
+     *
+     * @param mcpId compatibility alias
+     */
+    public static void validateMcpId(String mcpId) {
+        if (mcpId == null || !MCP_ID_PATTERN.matcher(mcpId).matches()) {
+            throw new IllegalArgumentException("Invalid MCP compatibility mcpId");
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.service.SyncEffectService;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import org.springframework.stereotype.Service;
+
+/**
+ * Owns Config access for the historical MCP serving Manifest.
+ *
+ * <p>The Manifest remains a serving compatibility index. Resource identity resolution must use
+ * {@code ai_resource}, never this storage.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class McpServingManifestStorage {
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    private final ConfigOperationService configOperationService;
+    
+    private final SyncEffectService syncEffectService;
+    
+    public McpServingManifestStorage(ConfigQueryChainService configQueryChainService,
+        ConfigOperationService configOperationService, SyncEffectService syncEffectService) {
+        this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+        this.syncEffectService = syncEffectService;
+    }
+    
+    /**
+     * Load one historical serving Manifest from its existing Config coordinate.
+     *
+     * @param namespaceId namespace identifier
+     * @param mcpId MCP compatibility alias
+     * @return decoded Manifest, or {@code null} when it does not exist
+     * @throws NacosException when Config query or decoding fails
+     */
+    public McpServerVersionInfo get(String namespaceId, String mcpId) throws NacosException {
+        validateCoordinate(namespaceId, mcpId);
+        ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(
+            McpConfigUtils.formatServerVersionInfoDataId(mcpId),
+            Constants.MCP_SERVER_VERSIONS_GROUP, namespaceId);
+        ConfigQueryChainResponse response = configQueryChainService.handle(request);
+        if (response == null) {
+            throw storageFailure("MCP serving Manifest query returned no response", null);
+        }
+        if (McpConfigUtils.isConfigNotFound(response.getStatus())) {
+            return null;
+        }
+        if (!McpConfigUtils.isConfigFound(response.getStatus())) {
+            throw storageFailure("MCP serving Manifest cannot be read: " + response.getMessage(),
+                null);
+        }
+        final McpServerVersionInfo result;
+        try {
+            result = JacksonUtils.toObj(response.getContent(), McpServerVersionInfo.class);
+        } catch (NacosDeserializationException e) {
+            throw storageFailure("MCP serving Manifest cannot be decoded", e);
+        }
+        try {
+            validateManifest(result);
+        } catch (IllegalArgumentException e) {
+            throw storageFailure("MCP serving Manifest has invalid identity fields", e);
+        }
+        if (!mcpId.equals(result.getId())) {
+            throw storageFailure("MCP serving Manifest id does not match its Config coordinate",
+                null);
+        }
+        return result;
+    }
+    
+    /**
+     * Publish one serving Manifest at the existing Config coordinate and wait for local effect.
+     *
+     * @param namespaceId namespace identifier
+     * @param manifest serving Manifest
+     * @throws NacosException when Config publication fails
+     */
+    public void publish(String namespaceId, McpServerVersionInfo manifest) throws NacosException {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        validateManifest(manifest);
+        ConfigFormV3 form = buildForm(namespaceId, manifest);
+        long startTimeStamp = System.currentTimeMillis();
+        configOperationService.publishConfig(form, new ConfigRequestInfo(), null);
+        if (syncEffectService != null) {
+            syncEffectService.toSync(form, startTimeStamp);
+        }
+    }
+    
+    /**
+     * Delete one serving Manifest from the existing Config coordinate.
+     *
+     * @param namespaceId namespace identifier
+     * @param mcpId MCP compatibility alias
+     * @throws NacosException when Config deletion fails
+     */
+    public void delete(String namespaceId, String mcpId) throws NacosException {
+        validateCoordinate(namespaceId, mcpId);
+        configOperationService.deleteConfig(
+            McpConfigUtils.formatServerVersionInfoDataId(mcpId),
+            Constants.MCP_SERVER_VERSIONS_GROUP, namespaceId, null, null, "nacos", null);
+    }
+    
+    private ConfigFormV3 buildForm(String namespaceId, McpServerVersionInfo manifest)
+        throws NacosException {
+        final String content;
+        try {
+            content = JacksonUtils.toJson(manifest);
+        } catch (NacosSerializationException e) {
+            throw storageFailure("MCP serving Manifest cannot be encoded", e);
+        }
+        ConfigFormV3 result = new ConfigFormV3();
+        result.setGroupName(Constants.MCP_SERVER_VERSIONS_GROUP);
+        result.setGroup(Constants.MCP_SERVER_VERSIONS_GROUP);
+        result.setNamespaceId(namespaceId);
+        result.setDataId(McpConfigUtils.formatServerVersionInfoDataId(manifest.getId()));
+        result.setContent(content);
+        result.setType(ConfigType.JSON.getType());
+        result.setAppName(manifest.getName());
+        result.setSrcUser("nacos");
+        result.setConfigTags(McpConfigUtils.buildMcpServerVersionConfigTags(manifest.getName()));
+        return result;
+    }
+    
+    private void validateCoordinate(String namespaceId, String mcpId) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        McpResourceExtSerializer.validateMcpId(mcpId);
+    }
+    
+    private void validateManifest(McpServerVersionInfo manifest) {
+        if (manifest == null) {
+            throw new IllegalArgumentException("MCP serving Manifest must not be null");
+        }
+        McpResourceExtSerializer.validateMcpId(manifest.getId());
+        if (StringUtils.isBlank(manifest.getName())) {
+            throw new IllegalArgumentException("MCP serving Manifest name must not be blank");
+        }
+    }
+    
+    private static NacosException storageFailure(String message, Throwable cause) {
+        return cause == null ? new NacosException(NacosException.SERVER_ERROR, message)
+            : new NacosException(NacosException.SERVER_ERROR, message, cause);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageContents.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageContents.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import java.util.Arrays;
+
+/**
+ * Immutable operation-scoped bytes for the three MCP Version content objects.
+ *
+ * @author Nacos
+ */
+public final class McpVersionStorageContents {
+    
+    private final byte[] serverContent;
+    
+    private final byte[] toolContent;
+    
+    private final byte[] resourceContent;
+    
+    public McpVersionStorageContents(byte[] serverContent, byte[] toolContent,
+        byte[] resourceContent) {
+        validateContent(serverContent, "Server", false);
+        validateContent(toolContent, "Tools", true);
+        validateContent(resourceContent, "Resources", true);
+        this.serverContent = copy(serverContent);
+        this.toolContent = copy(toolContent);
+        this.resourceContent = copy(resourceContent);
+    }
+    
+    public byte[] getServerContent() {
+        return copy(serverContent);
+    }
+    
+    public byte[] getToolContent() {
+        return copy(toolContent);
+    }
+    
+    public byte[] getResourceContent() {
+        return copy(resourceContent);
+    }
+    
+    boolean hasToolContent() {
+        return toolContent != null;
+    }
+    
+    boolean hasResourceContent() {
+        return resourceContent != null;
+    }
+    
+    private static void validateContent(byte[] content, String name, boolean optional) {
+        if (content == null) {
+            if (optional) {
+                return;
+            }
+            throw new IllegalArgumentException("MCP " + name + " content must not be null");
+        }
+        if (content.length == 0) {
+            throw new IllegalArgumentException("MCP " + name + " content must not be empty");
+        }
+    }
+    
+    private static byte[] copy(byte[] source) {
+        return source == null ? null : Arrays.copyOf(source, source.length);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializer.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Strict JSON serializer for an MCP Version storage descriptor.
+ *
+ * @author Nacos
+ */
+public final class McpVersionStorageDescriptorSerializer {
+    
+    private static final int MAX_KEY_LENGTH = 1024;
+    
+    private static final Set<String> FIELDS = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList("provider", "keyFormat", "serverKey", "toolKey",
+            "resourceKey", "schemaVersion")));
+    
+    private McpVersionStorageDescriptorSerializer() {
+    }
+    
+    /**
+     * Validate and serialize an MCP Version storage descriptor.
+     *
+     * @param descriptor storage descriptor
+     * @return canonical JSON stored in {@code ai_resource_version.storage}
+     */
+    public static String serialize(McpVersionStorageDescriptor descriptor) {
+        validate(descriptor);
+        Map<String, Object> projection = new LinkedHashMap<String, Object>();
+        projection.put("provider", descriptor.getProvider());
+        projection.put("keyFormat", descriptor.getKeyFormat());
+        projection.put("serverKey", descriptor.getServerKey());
+        if (descriptor.getToolKey() != null) {
+            projection.put("toolKey", descriptor.getToolKey());
+        }
+        if (descriptor.getResourceKey() != null) {
+            projection.put("resourceKey", descriptor.getResourceKey());
+        }
+        projection.put("schemaVersion", McpVersionStorageDescriptor.SCHEMA_VERSION);
+        try {
+            return JacksonUtils.toJson(projection);
+        } catch (NacosSerializationException e) {
+            throw new IllegalArgumentException(
+                "Unable to serialize MCP Version storage descriptor", e);
+        }
+    }
+    
+    /**
+     * Deserialize and strictly validate an MCP Version storage descriptor.
+     *
+     * @param json persisted JSON
+     * @return validated descriptor
+     */
+    public static McpVersionStorageDescriptor deserialize(String json) {
+        Map<?, ?> root = McpJsonValidationSupport.parseObject(json,
+            "MCP Version storage descriptor");
+        McpJsonValidationSupport.rejectUnknownFields(root, FIELDS,
+            "MCP Version storage descriptor");
+        McpVersionStorageDescriptor result = new McpVersionStorageDescriptor();
+        result.setProvider(McpJsonValidationSupport.requireText(root, "provider",
+            "MCP Version storage descriptor"));
+        result.setKeyFormat(McpJsonValidationSupport.requireText(root, "keyFormat",
+            "MCP Version storage descriptor"));
+        result.setServerKey(McpJsonValidationSupport.requireText(root, "serverKey",
+            "MCP Version storage descriptor"));
+        result.setToolKey(McpJsonValidationSupport.optionalText(root, "toolKey",
+            "MCP Version storage descriptor"));
+        result.setResourceKey(McpJsonValidationSupport.optionalText(root, "resourceKey",
+            "MCP Version storage descriptor"));
+        result.setSchemaVersion(McpJsonValidationSupport.requireInteger(root, "schemaVersion",
+            "MCP Version storage descriptor"));
+        validate(result);
+        return result;
+    }
+    
+    /**
+     * Validate an MCP Version storage descriptor against schema version 1.
+     *
+     * @param descriptor storage descriptor
+     */
+    public static void validate(McpVersionStorageDescriptor descriptor) {
+        if (descriptor == null) {
+            throw new IllegalArgumentException(
+                "MCP Version storage descriptor must not be null");
+        }
+        if (!McpVersionStorageDescriptor.PROVIDER.equals(descriptor.getProvider())) {
+            throw new IllegalArgumentException("MCP Version storage provider must be "
+                + McpVersionStorageDescriptor.PROVIDER);
+        }
+        if (!McpVersionStorageDescriptor.KEY_FORMAT.equals(descriptor.getKeyFormat())) {
+            throw new IllegalArgumentException("MCP Version storage keyFormat must be "
+                + McpVersionStorageDescriptor.KEY_FORMAT);
+        }
+        if (!Integer.valueOf(McpVersionStorageDescriptor.SCHEMA_VERSION)
+            .equals(descriptor.getSchemaVersion())) {
+            throw new IllegalArgumentException("MCP Version storage schemaVersion must be "
+                + McpVersionStorageDescriptor.SCHEMA_VERSION);
+        }
+        StorageCoordinate server = parseKey(descriptor.getServerKey(),
+            Constants.MCP_SERVER_GROUP, Constants.MCP_SERVER_SPEC_DATA_ID_SUFFIX, "serverKey");
+        validateOptionalKey(descriptor.getToolKey(), Constants.MCP_SERVER_TOOL_GROUP,
+            Constants.MCP_SERVER_TOOL_DATA_ID_SUFFIX, "toolKey", server.namespaceId());
+        validateOptionalKey(descriptor.getResourceKey(), Constants.MCP_SERVER_RESOURCE_GROUP,
+            Constants.MCP_SERVER_RESOURCE_DATA_ID_SUFFIX, "resourceKey", server.namespaceId());
+    }
+    
+    static StorageCoordinate parseKey(String key, String expectedGroup, String expectedSuffix,
+        String fieldName) {
+        if (key == null || key.length() > MAX_KEY_LENGTH) {
+            throw new IllegalArgumentException("Invalid MCP Version storage " + fieldName);
+        }
+        int namespaceSeparator = key.indexOf(':');
+        int groupSeparator = key.indexOf(':', namespaceSeparator + 1);
+        if (namespaceSeparator <= 0 || groupSeparator <= namespaceSeparator + 1
+            || groupSeparator == key.length() - 1) {
+            throw new IllegalArgumentException("Invalid MCP Version storage " + fieldName);
+        }
+        String namespaceId = key.substring(0, namespaceSeparator);
+        String group = key.substring(namespaceSeparator + 1, groupSeparator);
+        String dataId = key.substring(groupSeparator + 1);
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        if (!expectedGroup.equals(group) || dataId.length() <= expectedSuffix.length()
+            || !dataId.endsWith(expectedSuffix)) {
+            throw new IllegalArgumentException("Invalid MCP Version storage " + fieldName);
+        }
+        return new StorageCoordinate(namespaceId, group, dataId);
+    }
+    
+    private static void validateOptionalKey(String key, String expectedGroup,
+        String expectedSuffix, String fieldName, String expectedNamespaceId) {
+        if (key == null) {
+            return;
+        }
+        StorageCoordinate coordinate = parseKey(key, expectedGroup, expectedSuffix, fieldName);
+        if (!expectedNamespaceId.equals(coordinate.namespaceId())) {
+            throw new IllegalArgumentException(
+                "MCP Version storage keys must use the same namespace");
+        }
+    }
+    
+    record StorageCoordinate(String namespaceId, String group, String dataId) {
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.mcp.McpServerStorageInfo;
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Composes stable logical storage keys for the three existing MCP Config objects.
+ *
+ * @author Nacos
+ */
+public final class McpVersionStorageKeyComposer {
+    
+    private static final int MAX_VERSION_LENGTH = 64;
+    
+    private McpVersionStorageKeyComposer() {
+    }
+    
+    /**
+     * Compose a descriptor for a new MCP Version using deterministic existing data ids.
+     *
+     * @param namespaceId namespace identifier
+     * @param mcpId historical UUID-shaped compatibility id
+     * @param version exact MCP Version
+     * @param includeTools whether the Version has Tools content
+     * @param includeResources whether the Version has Resources content
+     * @return validated storage descriptor
+     */
+    public static McpVersionStorageDescriptor compose(String namespaceId, String mcpId,
+        String version, boolean includeTools, boolean includeResources) {
+        validateIdentity(namespaceId, mcpId, version);
+        String toolDataId = includeTools
+            ? McpConfigUtils.formatServerToolSpecDataId(mcpId, version) : null;
+        String resourceDataId = includeResources
+            ? McpConfigUtils.formatServerResourceSpecDataId(mcpId, version) : null;
+        return build(namespaceId, McpConfigUtils.formatServerSpecInfoDataId(mcpId, version),
+            toolDataId, resourceDataId);
+    }
+    
+    /**
+     * Build a zero-copy descriptor for historical MCP content.
+     *
+     * <p>The optional Tools and Resources data ids are taken from the historical Server object
+     * rather than inferred, so reconciliation never points to content that the old object did not
+     * reference.</p>
+     *
+     * @param namespaceId namespace identifier
+     * @param mcpId historical UUID-shaped compatibility id
+     * @param version exact MCP Version
+     * @param legacyStorageInfo historical Server storage object
+     * @return validated descriptor pointing to the existing Config coordinates
+     */
+    public static McpVersionStorageDescriptor fromLegacy(String namespaceId, String mcpId,
+        String version, McpServerStorageInfo legacyStorageInfo) {
+        if (legacyStorageInfo == null) {
+            throw new IllegalArgumentException("Legacy MCP Server storage info must not be null");
+        }
+        validateIdentity(namespaceId, mcpId, version);
+        return build(namespaceId, McpConfigUtils.formatServerSpecInfoDataId(mcpId, version),
+            blankToNull(legacyStorageInfo.getToolsDescriptionRef()),
+            blankToNull(legacyStorageInfo.getResourceDescriptionRef()));
+    }
+    
+    private static McpVersionStorageDescriptor build(String namespaceId, String serverDataId,
+        String toolDataId, String resourceDataId) {
+        McpVersionStorageDescriptor result = new McpVersionStorageDescriptor();
+        result.setProvider(McpVersionStorageDescriptor.PROVIDER);
+        result.setKeyFormat(McpVersionStorageDescriptor.KEY_FORMAT);
+        result.setServerKey(key(namespaceId, Constants.MCP_SERVER_GROUP, serverDataId));
+        if (toolDataId != null) {
+            result.setToolKey(key(namespaceId, Constants.MCP_SERVER_TOOL_GROUP, toolDataId));
+        }
+        if (resourceDataId != null) {
+            result.setResourceKey(key(namespaceId, Constants.MCP_SERVER_RESOURCE_GROUP,
+                resourceDataId));
+        }
+        result.setSchemaVersion(McpVersionStorageDescriptor.SCHEMA_VERSION);
+        McpVersionStorageDescriptorSerializer.validate(result);
+        return result;
+    }
+    
+    private static String key(String namespaceId, String group, String dataId) {
+        return namespaceId + ':' + group + ':' + dataId;
+    }
+    
+    private static void validateIdentity(String namespaceId, String mcpId, String version) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        McpResourceExtSerializer.validateMcpId(mcpId);
+        if (version == null || version.isEmpty() || version.length() > MAX_VERSION_LENGTH) {
+            throw new IllegalArgumentException("Invalid MCP Version: " + version);
+        }
+    }
+    
+    private static String blankToNull(String value) {
+        return StringUtils.isBlank(value) ? null : value;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageService.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * Stores the three content objects of one MCP Version in dependency order.
+ *
+ * <p>This component owns content bytes only. Resource and Version rows, lifecycle state and
+ * compatibility projections remain orchestration responsibilities.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class McpVersionStorageService {
+    
+    private final AiResourceStorageRouter storageRouter;
+    
+    public McpVersionStorageService() {
+        this(AiResourceStorageRouter.getInstance());
+    }
+    
+    McpVersionStorageService(AiResourceStorageRouter storageRouter) {
+        this.storageRouter = Objects.requireNonNull(storageRouter, "storageRouter");
+    }
+    
+    /**
+     * Save Tools and Resources before the Server object that references them.
+     *
+     * @param descriptor Version storage descriptor
+     * @param contents exact content bytes
+     * @throws NacosException when the selected provider fails
+     */
+    public void save(McpVersionStorageDescriptor descriptor, McpVersionStorageContents contents)
+        throws NacosException {
+        McpVersionStorageDescriptorSerializer.validate(descriptor);
+        validateContents(descriptor, contents);
+        if (descriptor.getToolKey() != null) {
+            saveContent(descriptor, descriptor.getToolKey(), contents.getToolContent());
+        }
+        if (descriptor.getResourceKey() != null) {
+            saveContent(descriptor, descriptor.getResourceKey(), contents.getResourceContent());
+        }
+        saveContent(descriptor, descriptor.getServerKey(), contents.getServerContent());
+    }
+    
+    /**
+     * Load the Server and every optional object selected by the persisted descriptor.
+     *
+     * @param descriptor Version storage descriptor
+     * @return exact content bytes
+     * @throws NacosException when content is missing or cannot be read
+     */
+    public McpVersionStorageContents load(McpVersionStorageDescriptor descriptor)
+        throws NacosException {
+        checkedDescriptor(descriptor);
+        byte[] server = loadRequired(descriptor, descriptor.getServerKey(), "Server");
+        byte[] tools = descriptor.getToolKey() == null ? null
+            : loadRequired(descriptor, descriptor.getToolKey(), "Tools");
+        byte[] resources = descriptor.getResourceKey() == null ? null
+            : loadRequired(descriptor, descriptor.getResourceKey(), "Resources");
+        return new McpVersionStorageContents(server, tools, resources);
+    }
+    
+    /**
+     * Attempt every referenced content deletion in Resources, Tools, Server order.
+     *
+     * @param descriptor Version storage descriptor
+     * @throws NacosException after all attempts when at least one deletion fails
+     */
+    public void delete(McpVersionStorageDescriptor descriptor) throws NacosException {
+        checkedDescriptor(descriptor);
+        NacosException failure = null;
+        if (descriptor.getResourceKey() != null) {
+            failure = deleteContent(descriptor, descriptor.getResourceKey(), failure);
+        }
+        if (descriptor.getToolKey() != null) {
+            failure = deleteContent(descriptor, descriptor.getToolKey(), failure);
+        }
+        failure = deleteContent(descriptor, descriptor.getServerKey(), failure);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+    
+    private void validateContents(McpVersionStorageDescriptor descriptor,
+        McpVersionStorageContents contents) {
+        if (contents == null) {
+            throw new IllegalArgumentException("MCP Version storage contents must not be null");
+        }
+        if ((descriptor.getToolKey() != null) != contents.hasToolContent()) {
+            throw new IllegalArgumentException(
+                "MCP Tools content and storage key presence must match");
+        }
+        if ((descriptor.getResourceKey() != null) != contents.hasResourceContent()) {
+            throw new IllegalArgumentException(
+                "MCP Resources content and storage key presence must match");
+        }
+    }
+    
+    private void checkedDescriptor(McpVersionStorageDescriptor descriptor) throws NacosException {
+        try {
+            McpVersionStorageDescriptorSerializer.validate(descriptor);
+        } catch (IllegalArgumentException e) {
+            throw storageFailure("Invalid MCP Version storage descriptor", e);
+        }
+    }
+    
+    private void saveContent(McpVersionStorageDescriptor descriptor, String key, byte[] content)
+        throws NacosException {
+        StorageKey storageKey = new StorageKey(descriptor.getProvider(), key);
+        try {
+            route(storageKey).save(storageKey, content);
+        } catch (IllegalArgumentException e) {
+            throw storageFailure("MCP Version content cannot be saved", e);
+        }
+    }
+    
+    private byte[] loadRequired(McpVersionStorageDescriptor descriptor, String key,
+        String contentName) throws NacosException {
+        StorageKey storageKey = new StorageKey(descriptor.getProvider(), key);
+        final byte[] result;
+        try {
+            result = route(storageKey).get(storageKey);
+        } catch (IllegalArgumentException e) {
+            throw storageFailure("Invalid MCP Version storage key", e);
+        }
+        if (result == null || result.length == 0) {
+            throw storageFailure("MCP " + contentName + " content does not exist", null);
+        }
+        return result;
+    }
+    
+    private NacosException deleteContent(McpVersionStorageDescriptor descriptor, String key,
+        NacosException previous) {
+        StorageKey storageKey = new StorageKey(descriptor.getProvider(), key);
+        try {
+            route(storageKey).delete(storageKey);
+            return previous;
+        } catch (NacosException e) {
+            return appendFailure(previous, e);
+        } catch (RuntimeException e) {
+            return appendFailure(previous, storageFailure("Invalid MCP Version storage key", e));
+        }
+    }
+    
+    private AiResourceStorage route(StorageKey storageKey) throws NacosException {
+        try {
+            return storageRouter.route(storageKey);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw storageFailure(
+                "MCP Version storage provider is unavailable: " + storageKey.getProvider(), e);
+        }
+    }
+    
+    private static NacosException appendFailure(NacosException previous, NacosException current) {
+        if (previous == null) {
+            return current;
+        }
+        previous.addSuppressed(current);
+        return previous;
+    }
+    
+    private static NacosException storageFailure(String message, Throwable cause) {
+        return cause == null ? new NacosException(NacosException.SERVER_ERROR, message)
+            : new NacosException(NacosException.SERVER_ERROR, message, cause);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.ai.storage;
 
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.service.SyncEffectService;
 import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
@@ -31,7 +33,6 @@ import com.alibaba.nacos.config.server.service.ConfigOperationService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
-import com.alibaba.nacos.ai.service.SyncEffectService;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
 import com.alibaba.nacos.config.server.utils.ConfigPersistContext;
@@ -41,12 +42,13 @@ import java.nio.charset.StandardCharsets;
 /**
  * Nacos Config based {@link AiResourceStorage} implementation.
  *
- * <p>Supports Skill, AgentSpec, Prompt and Agent Version resources.
+ * <p>Supports Skill, AgentSpec, Prompt, Agent Version and allowlisted MCP resources.
  * StorageKey.key format:
  * <ul>
  *   <li>Legacy (Skill): {@code namespaceId:name:version:filePath} (4-part, defaults to skill__ prefix)</li>
  *   <li>Typed: {@code namespaceId:resourceType:name:version:filePath} (5-part, resourceType = "skill", "agentspec" or "prompt")</li>
  *   <li>Agent Version: {@code namespaceId:agent-version:dataId} (3-part opaque key)</li>
+ *   <li>MCP Version content: {@code namespaceId:mcp-owned-group:dataId} (3-part opaque key)</li>
  * </ul>
  * File path convention: main = {@link #getMainFilePath()} / {@link #getMainFilePath(String)},
  * resources = {@link #getResourceFilePath(String, String)} / {@link #getAgentSpecResourceFilePath(String, String)},
@@ -192,9 +194,8 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
         long startTimeStamp = System.currentTimeMillis();
         KeyParts parts = parse(storageKey);
         ConfigForm form = new ConfigForm();
-        String physicalDataId = NacosAiConfigKeyCodec.toPhysicalDataId(parts.dataId());
-        String physicalGroup =
-            NacosAiConfigKeyCodec.toPhysicalGroup(parts.group(), parts.groupPrefix());
+        String physicalDataId = toPhysicalDataId(parts);
+        String physicalGroup = toPhysicalGroup(parts);
         form.setDataId(physicalDataId);
         form.setGroup(physicalGroup);
         form.setNamespaceId(parts.namespaceId());
@@ -223,9 +224,8 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     @Override
     public byte[] get(StorageKey storageKey) throws NacosException {
         KeyParts parts = parse(storageKey);
-        String physicalDataId = NacosAiConfigKeyCodec.toPhysicalDataId(parts.dataId());
-        String physicalGroup =
-            NacosAiConfigKeyCodec.toPhysicalGroup(parts.group(), parts.groupPrefix());
+        String physicalDataId = toPhysicalDataId(parts);
+        String physicalGroup = toPhysicalGroup(parts);
         ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(
             physicalDataId, physicalGroup, parts.namespaceId());
         ConfigQueryChainResponse response = configQueryChainService.handle(request);
@@ -239,9 +239,8 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     @Override
     public void delete(StorageKey storageKey) throws NacosException {
         KeyParts parts = parse(storageKey);
-        String physicalDataId = NacosAiConfigKeyCodec.toPhysicalDataId(parts.dataId());
-        String physicalGroup =
-            NacosAiConfigKeyCodec.toPhysicalGroup(parts.group(), parts.groupPrefix());
+        String physicalDataId = toPhysicalDataId(parts);
+        String physicalGroup = toPhysicalGroup(parts);
         try (ConfigPersistContext.Guard ignored = ConfigPersistContext.withSkipHistory()) {
             configOperationService.deleteConfig(physicalDataId, physicalGroup, parts.namespaceId(),
                 null, null, "nacos",
@@ -269,9 +268,10 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     }
     
     /**
-     * Parse StorageKey into KeyParts. Supports four key formats:
+     * Parse StorageKey into KeyParts. Supports five key formats:
      * <ul>
      *   <li>Agent Version: {@code namespaceId:agent-version:dataId} → group = agent-version</li>
+     *   <li>MCP content: {@code namespaceId:mcp-owned-group:dataId} → exact legacy coordinate</li>
      *   <li>Legacy 4-part (Skill): {@code namespaceId:name:version:filePath} → group = skill__{name}__{version}</li>
      *   <li>Legacy 4-part manifest: {@code namespaceId:name::filePath} (blank version) → group = skill_{name}</li>
      *   <li>Typed 5-part: {@code namespaceId:resourceType:name:version:filePath} → group = {prefix}{name}__{version}</li>
@@ -281,6 +281,10 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     static KeyParts parse(StorageKey storageKey) {
         if (storageKey == null || StringUtils.isBlank(storageKey.getKey())) {
             throw new IllegalArgumentException("StorageKey.key is blank");
+        }
+        KeyParts mcpParts = parseMcpStorageKey(storageKey.getKey());
+        if (mcpParts != null) {
+            return mcpParts;
         }
         String[] agentVersionParts = storageKey.getKey().split(":", -1);
         if (agentVersionParts.length == 3 && AGENT_VERSION_GROUP.equals(agentVersionParts[1])
@@ -339,6 +343,56 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
             group = SkillUtils.buildSkillVersionGroup(skillName, version);
         }
         return new KeyParts(namespaceId, group, SkillUtils.SKILL_GROUP_PREFIX, filePath);
+    }
+    
+    private static KeyParts parseMcpStorageKey(String key) {
+        int namespaceSeparator = key.indexOf(':');
+        if (namespaceSeparator < 0) {
+            return null;
+        }
+        int groupSeparator = key.indexOf(':', namespaceSeparator + 1);
+        if (groupSeparator < 0) {
+            return null;
+        }
+        String group = key.substring(namespaceSeparator + 1, groupSeparator);
+        if (!isMcpStorageGroup(group)) {
+            return null;
+        }
+        String namespaceId = key.substring(0, namespaceSeparator);
+        String dataId = key.substring(groupSeparator + 1);
+        if (!isMcpStorageDataId(group, dataId)) {
+            return null;
+        }
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        return new KeyParts(namespaceId, group, group, dataId);
+    }
+    
+    private static boolean isMcpStorageDataId(String group, String dataId) {
+        String suffix;
+        if (Constants.MCP_SERVER_GROUP.equals(group)) {
+            suffix = Constants.MCP_SERVER_SPEC_DATA_ID_SUFFIX;
+        } else if (Constants.MCP_SERVER_TOOL_GROUP.equals(group)) {
+            suffix = Constants.MCP_SERVER_TOOL_DATA_ID_SUFFIX;
+        } else {
+            suffix = Constants.MCP_SERVER_RESOURCE_DATA_ID_SUFFIX;
+        }
+        return dataId.length() > suffix.length() && dataId.endsWith(suffix);
+    }
+    
+    private static boolean isMcpStorageGroup(String group) {
+        return Constants.MCP_SERVER_GROUP.equals(group)
+            || Constants.MCP_SERVER_TOOL_GROUP.equals(group)
+            || Constants.MCP_SERVER_RESOURCE_GROUP.equals(group);
+    }
+    
+    private static String toPhysicalDataId(KeyParts parts) {
+        return isMcpStorageGroup(parts.group()) ? parts.dataId()
+            : NacosAiConfigKeyCodec.toPhysicalDataId(parts.dataId());
+    }
+    
+    private static String toPhysicalGroup(KeyParts parts) {
+        return isMcpStorageGroup(parts.group()) ? parts.group()
+            : NacosAiConfigKeyCodec.toPhysicalGroup(parts.group(), parts.groupPrefix());
     }
     
     private static void validateAgentVersionDataId(String dataId) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocatorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocatorTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.ai.service.mcp.storage.McpResourceExtSerializer;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpResourceLocatorTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    private static final String OTHER_MCP_ID = "11111111-1111-1111-1111-111111111111";
+    
+    @Mock
+    private AiResourcePersistService resourcePersistService;
+    
+    private McpResourceLocator locator;
+    
+    @BeforeEach
+    void setUp() {
+        locator = new McpResourceLocator(resourcePersistService);
+    }
+    
+    @Test
+    void testLocateByNameUsesExactMcpResourceQuery() throws Exception {
+        AiResource expected = resource("public", "demo", MCP_ID);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(1, 1, expected));
+        
+        AiResource result = locator.locate("public", "demo", null);
+        
+        assertEquals(expected, result);
+        ArgumentCaptor<QueryCondition> conditionCaptor =
+            ArgumentCaptor.forClass(QueryCondition.class);
+        verify(resourcePersistService).list(conditionCaptor.capture(), eq(1), eq(2));
+        assertEquals("public", conditionCaptor.getValue().getNamespaceId());
+        assertEquals(AiResourceConstants.RESOURCE_TYPE_MCP,
+            conditionCaptor.getValue().getType());
+        assertEquals("demo", conditionCaptor.getValue().getOrGroup().get("name"));
+    }
+    
+    @Test
+    void testLocateByNameAndIdCrossChecksAlias() throws Exception {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(1, 1, resource("public", "demo", MCP_ID)));
+        assertEquals("demo", locator.locate("public", "demo", MCP_ID).getName());
+        NacosApiException conflict = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "demo", OTHER_MCP_ID));
+        assertEquals(NacosException.INVALID_PARAM, conflict.getErrCode());
+        assertEquals(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(), conflict.getDetailErrCode());
+    }
+    
+    @Test
+    void testLocateByIdPagesUntilUniqueMatch() throws Exception {
+        Page<AiResource> first = page(2, 2, resource("public", "other", OTHER_MCP_ID));
+        Page<AiResource> second = page(2, 2, resource("public", "demo", MCP_ID));
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(first, second);
+        
+        AiResource result = locator.locate("public", null, MCP_ID);
+        
+        assertEquals("demo", result.getName());
+        verify(resourcePersistService, times(2))
+            .list(any(QueryCondition.class), anyInt(), eq(100));
+    }
+    
+    @Test
+    void testLocateByIdRejectsDuplicateAliasAcrossPages() {
+        Page<AiResource> first = page(2, 2, resource("public", "one", MCP_ID));
+        Page<AiResource> second = page(2, 2, resource("public", "two", MCP_ID));
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(first, second);
+        NacosApiException conflict = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", null, MCP_ID));
+        assertEquals(NacosException.CONFLICT, conflict.getErrCode());
+        assertEquals(ErrorCode.RESOURCE_CONFLICT.getCode(), conflict.getDetailErrCode());
+    }
+    
+    @Test
+    void testLocateByNameRejectsMultipleSourceRows() {
+        List<AiResource> duplicates = Arrays.asList(resource("public", "demo", MCP_ID),
+            resource("public", "demo", OTHER_MCP_ID));
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(2, 1, duplicates));
+        NacosApiException conflict = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "demo", null));
+        assertEquals(NacosException.CONFLICT, conflict.getErrCode());
+    }
+    
+    @Test
+    void testLocateRejectsMalformedStoredExtension() {
+        AiResource invalid = resource("public", "demo", MCP_ID);
+        invalid.setExt("{\"schemaVersion\":1}");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(1, 1, invalid));
+        NacosApiException conflict = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "demo", null));
+        assertEquals(NacosException.CONFLICT, conflict.getErrCode());
+        assertEquals(ErrorCode.RESOURCE_CONFLICT.getCode(), conflict.getDetailErrCode());
+    }
+    
+    @Test
+    void testLocateReturnsControlledNotFound() {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(0, 0, Collections.emptyList()));
+        NacosApiException missing = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "missing", null));
+        assertEquals(NacosException.NOT_FOUND, missing.getErrCode());
+        assertEquals(ErrorCode.MCP_SERVER_NOT_FOUND.getCode(), missing.getDetailErrCode());
+    }
+    
+    @Test
+    void testLocateValidatesInputBeforeQuery() {
+        assertThrows(NacosApiException.class, () -> locator.locate("public", null, null));
+        assertThrows(NacosApiException.class, () -> locator.locate("public", null, "bad-id"));
+        assertThrows(NacosApiException.class,
+            () -> locator.locate("invalid namespace", "demo", null));
+        verifyNoInteractions(resourcePersistService);
+    }
+    
+    @Test
+    void testBlankNamespaceUsesMcpDefault() throws Exception {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(1, 1, resource("public", "demo", MCP_ID)));
+        locator.locate(" ", "demo", null);
+        ArgumentCaptor<QueryCondition> captor = ArgumentCaptor.forClass(QueryCondition.class);
+        verify(resourcePersistService).list(captor.capture(), eq(1), eq(2));
+        assertEquals("public", captor.getValue().getNamespaceId());
+        verify(resourcePersistService, never()).find(any(), any(), any());
+    }
+    
+    private AiResource resource(String namespaceId, String name, String mcpId) {
+        AiResource result = new AiResource();
+        result.setNamespaceId(namespaceId);
+        result.setName(name);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        McpResourceExt ext = new McpResourceExt();
+        ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        ext.setMcpId(mcpId);
+        result.setExt(McpResourceExtSerializer.serialize(ext));
+        return result;
+    }
+    
+    private Page<AiResource> page(int totalCount, int pagesAvailable, AiResource... resources) {
+        return page(totalCount, pagesAvailable, Arrays.asList(resources));
+    }
+    
+    private Page<AiResource> page(int totalCount, int pagesAvailable,
+        List<AiResource> resources) {
+        Page<AiResource> result = new Page<>();
+        result.setTotalCount(totalCount);
+        result.setPagesAvailable(pagesAvailable);
+        result.setPageItems(resources);
+        return result;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpResourceExtSerializerTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    @Test
+    void testRoundTripUsesCanonicalProjection() {
+        McpResourceExt original = new McpResourceExt();
+        original.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        original.setMcpId(MCP_ID);
+        
+        String json = McpResourceExtSerializer.serialize(original);
+        McpResourceExt restored = McpResourceExtSerializer.deserialize(json);
+        
+        assertEquals("{\"schemaVersion\":1,\"mcpId\":\"" + MCP_ID + "\"}", json);
+        assertEquals(McpResourceExt.SCHEMA_VERSION, restored.getSchemaVersion());
+        assertEquals(MCP_ID, restored.getMcpId());
+    }
+    
+    @Test
+    void testAcceptUppercaseUuidHex() {
+        String mcpId = "4D7939C0-72EA-4EF4-B232-418D1E16B45C";
+        McpResourceExt result = McpResourceExtSerializer.deserialize(
+            "{\"schemaVersion\":1,\"mcpId\":\"" + mcpId + "\"}");
+        assertEquals(mcpId, result.getMcpId());
+    }
+    
+    @Test
+    void testRejectInvalidTypedValues() {
+        McpResourceExt ext = new McpResourceExt();
+        assertThrows(IllegalArgumentException.class, () -> McpResourceExtSerializer.validate(null));
+        assertThrows(IllegalArgumentException.class, () -> McpResourceExtSerializer.serialize(ext));
+        ext.setSchemaVersion(2);
+        ext.setMcpId(MCP_ID);
+        assertThrows(IllegalArgumentException.class, () -> McpResourceExtSerializer.serialize(ext));
+        ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        ext.setMcpId("not-a-uuid");
+        assertThrows(IllegalArgumentException.class, () -> McpResourceExtSerializer.serialize(ext));
+    }
+    
+    @Test
+    void testRejectInvalidJsonShape() {
+        assertInvalid(null);
+        assertInvalid("");
+        assertInvalid("   ");
+        assertInvalid("null");
+        assertInvalid("[]");
+        assertInvalid("not-json");
+        assertInvalid("{\"schemaVersion\":1}");
+        assertInvalid("{\"schemaVersion\":1.0,\"mcpId\":\"" + MCP_ID + "\"}");
+        assertInvalid("{\"schemaVersion\":1,\"mcpId\":1}");
+        assertInvalid("{\"schemaVersion\":1,\"mcpId\":\"" + MCP_ID
+            + "\",\"extra\":true}");
+        assertInvalid("{\"schemaVersion\":1,\"schemaVersion\":1,\"mcpId\":\""
+            + MCP_ID + "\"}");
+        assertInvalid("{\"schemaVersion\":1,\"mcpId\":\"" + MCP_ID + "\"}{}");
+    }
+    
+    private void assertInvalid(String json) {
+        assertThrows(IllegalArgumentException.class,
+            () -> McpResourceExtSerializer.deserialize(json));
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.service.SyncEffectService;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpServingManifestStorageTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    @Mock
+    private ConfigQueryChainService configQueryChainService;
+    
+    @Mock
+    private ConfigOperationService configOperationService;
+    
+    @Mock
+    private SyncEffectService syncEffectService;
+    
+    private McpServingManifestStorage storage;
+    
+    @BeforeEach
+    void setUp() {
+        storage = new McpServingManifestStorage(configQueryChainService,
+            configOperationService, syncEffectService);
+    }
+    
+    @Test
+    void testGetUsesExistingCoordinateAndDecodesManifest() throws Exception {
+        ConfigQueryChainResponse response = foundResponse(JacksonUtils.toJson(manifest()));
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+        
+        McpServerVersionInfo result = storage.get("public", MCP_ID);
+        
+        assertEquals(MCP_ID, result.getId());
+        assertEquals("demo", result.getName());
+        ArgumentCaptor<ConfigQueryChainRequest> captor =
+            ArgumentCaptor.forClass(ConfigQueryChainRequest.class);
+        verify(configQueryChainService).handle(captor.capture());
+        assertEquals(McpConfigUtils.formatServerVersionInfoDataId(MCP_ID),
+            captor.getValue().getDataId());
+        assertEquals(Constants.MCP_SERVER_VERSIONS_GROUP, captor.getValue().getGroup());
+        assertEquals("public", captor.getValue().getTenant());
+    }
+    
+    @Test
+    void testGetReturnsNullWhenManifestDoesNotExist() throws Exception {
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+        assertNull(storage.get("public", MCP_ID));
+    }
+    
+    @Test
+    void testGetRejectsMalformedOrConflictingManifest() {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("not-json"));
+        assertEquals("MCP serving Manifest cannot be decoded",
+            assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+        McpServerVersionInfo conflicting = manifest();
+        conflicting.setId("11111111-1111-1111-1111-111111111111");
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse(JacksonUtils.toJson(conflicting)));
+        assertEquals("MCP serving Manifest id does not match its Config coordinate",
+            assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("{}"));
+        assertEquals("MCP serving Manifest has invalid identity fields",
+            assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+    }
+    
+    @Test
+    void testPublishPreservesCoordinateMetadataAndContent() throws Exception {
+        McpServerVersionInfo manifest = manifest();
+        
+        storage.publish("public", manifest);
+        
+        ArgumentCaptor<ConfigFormV3> captor = ArgumentCaptor.forClass(ConfigFormV3.class);
+        verify(configOperationService).publishConfig(captor.capture(), any(), isNull());
+        ConfigFormV3 form = captor.getValue();
+        assertEquals(McpConfigUtils.formatServerVersionInfoDataId(MCP_ID), form.getDataId());
+        assertEquals(Constants.MCP_SERVER_VERSIONS_GROUP, form.getGroup());
+        assertEquals(Constants.MCP_SERVER_VERSIONS_GROUP, form.getGroupName());
+        assertEquals("public", form.getNamespaceId());
+        assertEquals("demo", form.getAppName());
+        assertEquals(McpConfigUtils.buildMcpServerVersionConfigTags("demo"),
+            form.getConfigTags());
+        McpServerVersionInfo stored = JacksonUtils.toObj(form.getContent(),
+            McpServerVersionInfo.class);
+        assertEquals(MCP_ID, stored.getId());
+        assertEquals("demo", stored.getName());
+        verify(syncEffectService).toSync(same(form), anyLong());
+    }
+    
+    @Test
+    void testPublishRejectsInvalidManifestBeforeConfigAccess() {
+        McpServerVersionInfo manifest = manifest();
+        manifest.setName(" ");
+        assertThrows(IllegalArgumentException.class,
+            () -> storage.publish("public", manifest));
+        verifyNoInteractions(configOperationService, syncEffectService);
+    }
+    
+    @Test
+    void testDeleteUsesExistingCoordinate() throws Exception {
+        storage.delete("public", MCP_ID);
+        verify(configOperationService).deleteConfig(
+            McpConfigUtils.formatServerVersionInfoDataId(MCP_ID),
+            Constants.MCP_SERVER_VERSIONS_GROUP, "public", null, null, "nacos", null);
+        verify(syncEffectService, never()).toSync(any(), anyLong());
+    }
+    
+    @Test
+    void testRejectInvalidCoordinateBeforeConfigAccess() {
+        assertThrows(IllegalArgumentException.class,
+            () -> storage.get("invalid namespace", MCP_ID));
+        assertThrows(IllegalArgumentException.class, () -> storage.delete("public", "bad-id"));
+        verifyNoInteractions(configQueryChainService, configOperationService);
+    }
+    
+    private McpServerVersionInfo manifest() {
+        McpServerVersionInfo result = new McpServerVersionInfo();
+        result.setId(MCP_ID);
+        result.setName("demo");
+        return result;
+    }
+    
+    private ConfigQueryChainResponse foundResponse(String content) {
+        ConfigQueryChainResponse result = new ConfigQueryChainResponse();
+        result.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        result.setContent(content);
+        return result;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpVersionStorageDescriptorSerializerTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    @Test
+    void testRoundTripWithAllContentKeys() {
+        McpVersionStorageDescriptor original = descriptor();
+        
+        String json = McpVersionStorageDescriptorSerializer.serialize(original);
+        McpVersionStorageDescriptor restored =
+            McpVersionStorageDescriptorSerializer.deserialize(json);
+        
+        assertEquals("{\"provider\":\"nacos_config\",\"keyFormat\":\"mcp-config-v1\","
+            + "\"serverKey\":\"public:mcp-server:" + MCP_ID + "-1.0.0-mcp-server.json\","
+            + "\"toolKey\":\"public:mcp-tools:" + MCP_ID + "-1.0.0-mcp-tools.json\","
+            + "\"resourceKey\":\"public:mcp-resources:" + MCP_ID
+            + "-1.0.0-mcp-resources.json\",\"schemaVersion\":1}", json);
+        assertEquals(original.getProvider(), restored.getProvider());
+        assertEquals(original.getKeyFormat(), restored.getKeyFormat());
+        assertEquals(original.getServerKey(), restored.getServerKey());
+        assertEquals(original.getToolKey(), restored.getToolKey());
+        assertEquals(original.getResourceKey(), restored.getResourceKey());
+        assertEquals(original.getSchemaVersion(), restored.getSchemaVersion());
+    }
+    
+    @Test
+    void testOptionalKeysAreOmittedRatherThanNull() {
+        McpVersionStorageDescriptor descriptor = descriptor();
+        descriptor.setToolKey(null);
+        descriptor.setResourceKey(null);
+        
+        String json = McpVersionStorageDescriptorSerializer.serialize(descriptor);
+        McpVersionStorageDescriptor restored =
+            McpVersionStorageDescriptorSerializer.deserialize(json);
+        
+        assertEquals("{\"provider\":\"nacos_config\",\"keyFormat\":\"mcp-config-v1\","
+            + "\"serverKey\":\"public:mcp-server:" + MCP_ID
+            + "-1.0.0-mcp-server.json\",\"schemaVersion\":1}", json);
+        assertNull(restored.getToolKey());
+        assertNull(restored.getResourceKey());
+    }
+    
+    @Test
+    void testParserTreatsDataIdRemainderAsOpaque() {
+        McpVersionStorageDescriptor descriptor = descriptor();
+        descriptor.setServerKey("public:mcp-server:" + MCP_ID
+            + "-version:build-mcp-server.json");
+        McpVersionStorageDescriptorSerializer.validate(descriptor);
+    }
+    
+    @Test
+    void testRejectInvalidDescriptorValues() {
+        assertThrows(IllegalArgumentException.class,
+            () -> McpVersionStorageDescriptorSerializer.validate(null));
+        assertInvalidDescriptorValue(value -> value.setProvider("object-store"));
+        assertInvalidDescriptorValue(value -> value.setKeyFormat("other"));
+        assertInvalidDescriptorValue(value -> value.setSchemaVersion(2));
+        assertInvalidDescriptorValue(
+            value -> value.setServerKey("public:mcp-tools:x-mcp-tools.json"));
+        assertInvalidDescriptorValue(
+            value -> value.setServerKey("public:mcp-server:mcp-server.json"));
+        assertInvalidDescriptorValue(
+            value -> value.setToolKey("public:mcp-server:x-mcp-server.json"));
+        assertInvalidDescriptorValue(value -> value.setResourceKey(
+            "other:mcp-resources:x-mcp-resources.json"));
+        assertInvalidDescriptorValue(value -> value.setServerKey(
+            repeat("a", 1025) + ":mcp-server:x-mcp-server.json"));
+    }
+    
+    @Test
+    void testRejectInvalidJsonShape() {
+        String valid = McpVersionStorageDescriptorSerializer.serialize(descriptor());
+        assertInvalidJson(null);
+        assertInvalidJson("");
+        assertInvalidJson("[]");
+        assertInvalidJson("null");
+        assertInvalidJson("not-json");
+        assertInvalidJson(valid + "{}");
+        assertInvalidJson(valid.substring(0, valid.length() - 1) + ",\"extra\":true}");
+        assertInvalidJson(valid.replace("\"provider\":\"nacos_config\"", "\"provider\":1"));
+        assertInvalidJson(valid.replace("\"schemaVersion\":1", "\"schemaVersion\":1.0"));
+        assertInvalidJson(valid.replace("\"serverKey\":", "\"serverKey\":null,\"ignored\":"));
+        assertInvalidJson(valid.replace("{\"provider\":\"nacos_config\"",
+            "{\"provider\":\"nacos_config\",\"provider\":\"nacos_config\""));
+    }
+    
+    private void assertInvalidDescriptorValue(DescriptorMutation mutation) {
+        McpVersionStorageDescriptor descriptor = descriptor();
+        mutation.apply(descriptor);
+        assertThrows(IllegalArgumentException.class,
+            () -> McpVersionStorageDescriptorSerializer.serialize(descriptor));
+    }
+    
+    private void assertInvalidJson(String json) {
+        assertThrows(IllegalArgumentException.class,
+            () -> McpVersionStorageDescriptorSerializer.deserialize(json));
+    }
+    
+    private McpVersionStorageDescriptor descriptor() {
+        return McpVersionStorageKeyComposer.compose("public", MCP_ID, "1.0.0", true, true);
+    }
+    
+    private static String repeat(String value, int count) {
+        StringBuilder result = new StringBuilder(value.length() * count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+    
+    private interface DescriptorMutation {
+        
+        void apply(McpVersionStorageDescriptor descriptor);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpServerStorageInfo;
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpVersionStorageKeyComposerTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    @Test
+    void testComposeUsesExistingPhysicalCoordinates() {
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.compose(
+            "public", MCP_ID, "legacy-v1", true, true);
+        
+        assertEquals("public:mcp-server:" + MCP_ID + "-legacy-v1-mcp-server.json",
+            descriptor.getServerKey());
+        assertEquals("public:mcp-tools:" + MCP_ID + "-legacy-v1-mcp-tools.json",
+            descriptor.getToolKey());
+        assertEquals("public:mcp-resources:" + MCP_ID + "-legacy-v1-mcp-resources.json",
+            descriptor.getResourceKey());
+    }
+    
+    @Test
+    void testComposeOmitsAbsentOptionalContent() {
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.compose(
+            "namespace_1", MCP_ID, "1.0.0", false, false);
+        assertNull(descriptor.getToolKey());
+        assertNull(descriptor.getResourceKey());
+    }
+    
+    @Test
+    void testLegacyMappingUsesReferencedOptionalDataIds() {
+        McpServerStorageInfo legacy = new McpServerStorageInfo();
+        legacy.setToolsDescriptionRef("custom-1.0.0-mcp-tools.json");
+        legacy.setResourceDescriptionRef("custom-1.0.0-mcp-resources.json");
+        legacy.setPromptDescriptionRef("unchanged-prompt-ref");
+        
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.fromLegacy(
+            "public", MCP_ID, "1.0.0", legacy);
+        
+        assertEquals("public:mcp-tools:custom-1.0.0-mcp-tools.json",
+            descriptor.getToolKey());
+        assertEquals("public:mcp-resources:custom-1.0.0-mcp-resources.json",
+            descriptor.getResourceKey());
+        assertEquals("unchanged-prompt-ref", legacy.getPromptDescriptionRef());
+    }
+    
+    @Test
+    void testLegacyMappingTreatsBlankReferencesAsAbsent() {
+        McpServerStorageInfo legacy = new McpServerStorageInfo();
+        legacy.setToolsDescriptionRef(" ");
+        legacy.setResourceDescriptionRef(null);
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.fromLegacy(
+            "public", MCP_ID, "1.0.0", legacy);
+        assertNull(descriptor.getToolKey());
+        assertNull(descriptor.getResourceKey());
+    }
+    
+    @Test
+    void testRejectInvalidIdentityAndLegacyReference() {
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
+            "invalid namespace", MCP_ID, "1.0.0", false, false));
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
+            "public", "invalid", "1.0.0", false, false));
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
+            "public", MCP_ID, "", false, false));
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
+            "public", MCP_ID, repeat("v", 65), false, false));
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.fromLegacy(
+            "public", MCP_ID, "1.0.0", null));
+        McpServerStorageInfo legacy = new McpServerStorageInfo();
+        legacy.setToolsDescriptionRef("wrong.json");
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.fromLegacy(
+            "public", MCP_ID, "1.0.0", legacy));
+    }
+    
+    private static String repeat(String value, int count) {
+        StringBuilder result = new StringBuilder(value.length() * count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageServiceTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpVersionStorageServiceTest {
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    private static final byte[] SERVER = "server".getBytes(StandardCharsets.UTF_8);
+    
+    private static final byte[] TOOLS = "tools".getBytes(StandardCharsets.UTF_8);
+    
+    private static final byte[] RESOURCES = "resources".getBytes(StandardCharsets.UTF_8);
+    
+    @Mock
+    private AiResourceStorageRouter storageRouter;
+    
+    @Mock
+    private AiResourceStorage storage;
+    
+    private McpVersionStorageService service;
+    
+    @BeforeEach
+    void setUp() {
+        service = new McpVersionStorageService(storageRouter);
+    }
+    
+    @Test
+    void testDefaultConstructorIsAvailableForSpring() {
+        assertNotNull(new McpVersionStorageService());
+    }
+    
+    @Test
+    void testSaveWritesToolsResourcesThenServer() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(true, true);
+        
+        service.save(descriptor, contents(true, true));
+        
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        ArgumentCaptor<byte[]> contentCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(storage, times(3)).save(keyCaptor.capture(), contentCaptor.capture());
+        assertEquals(List.of(descriptor.getToolKey(), descriptor.getResourceKey(),
+            descriptor.getServerKey()), keys(keyCaptor));
+        assertArrayEquals(TOOLS, contentCaptor.getAllValues().get(0));
+        assertArrayEquals(RESOURCES, contentCaptor.getAllValues().get(1));
+        assertArrayEquals(SERVER, contentCaptor.getAllValues().get(2));
+    }
+    
+    @Test
+    void testSaveSupportsMissingOptionalFiles() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(false, false);
+        service.save(descriptor, contents(false, false));
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage).save(keyCaptor.capture(), any(byte[].class));
+        assertEquals(descriptor.getServerKey(), keyCaptor.getValue().getKey());
+    }
+    
+    @Test
+    void testSaveStopsAfterPartialFailureAndLeavesRetryableContent() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(true, true);
+        NacosException failure = new NacosException(NacosException.SERVER_ERROR, "resource failed");
+        doAnswer(invocation -> {
+            StorageKey key = invocation.getArgument(0);
+            if (descriptor.getResourceKey().equals(key.getKey())) {
+                throw failure;
+            }
+            return null;
+        }).when(storage).save(any(StorageKey.class), any(byte[].class));
+        
+        assertEquals(failure,
+            assertThrows(NacosException.class,
+                () -> service.save(descriptor, contents(true, true))));
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage, times(2)).save(keyCaptor.capture(), any(byte[].class));
+        assertEquals(List.of(descriptor.getToolKey(), descriptor.getResourceKey()),
+            keys(keyCaptor));
+    }
+    
+    @Test
+    void testSaveValidatesDescriptorAndContentPresenceBeforeRouting() {
+        McpVersionStorageDescriptor descriptor = descriptor(true, false);
+        assertThrows(IllegalArgumentException.class, () -> service.save(descriptor, null));
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(descriptor, contents(false, false)));
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(descriptor, contents(true, true)));
+        descriptor.setProvider("other");
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(descriptor, contents(true, false)));
+        verifyNoInteractions(storageRouter, storage);
+    }
+    
+    @Test
+    void testSaveWrapsProviderKeyRejection() throws Exception {
+        givenStorage();
+        doThrow(new IllegalArgumentException("bad key")).when(storage)
+            .save(any(StorageKey.class), any(byte[].class));
+        NacosException result = assertThrows(NacosException.class,
+            () -> service.save(descriptor(false, false), contents(false, false)));
+        assertEquals("MCP Version content cannot be saved", result.getErrMsg());
+        assertNotNull(result.getCause());
+    }
+    
+    @Test
+    void testLoadReadsEveryReferencedObject() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(true, true);
+        when(storage.get(any(StorageKey.class))).thenAnswer(invocation -> contentFor(
+            descriptor, invocation.getArgument(0)));
+        
+        McpVersionStorageContents result = service.load(descriptor);
+        
+        assertArrayEquals(SERVER, result.getServerContent());
+        assertArrayEquals(TOOLS, result.getToolContent());
+        assertArrayEquals(RESOURCES, result.getResourceContent());
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage, times(3)).get(keyCaptor.capture());
+        assertEquals(List.of(descriptor.getServerKey(), descriptor.getToolKey(),
+            descriptor.getResourceKey()), keys(keyCaptor));
+    }
+    
+    @Test
+    void testLoadSupportsDescriptorWithoutOptionalFiles() throws Exception {
+        givenStorage();
+        when(storage.get(any(StorageKey.class))).thenReturn(SERVER);
+        McpVersionStorageContents result = service.load(descriptor(false, false));
+        assertNull(result.getToolContent());
+        assertNull(result.getResourceContent());
+        verify(storage).get(any(StorageKey.class));
+    }
+    
+    @Test
+    void testLoadRejectsMissingOrEmptyReferencedContent() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(true, true);
+        when(storage.get(any(StorageKey.class))).thenReturn(null);
+        assertEquals("MCP Server content does not exist",
+            assertThrows(NacosException.class, () -> service.load(descriptor)).getErrMsg());
+        when(storage.get(any(StorageKey.class))).thenReturn(SERVER, null);
+        assertEquals("MCP Tools content does not exist",
+            assertThrows(NacosException.class, () -> service.load(descriptor)).getErrMsg());
+        when(storage.get(any(StorageKey.class))).thenReturn(SERVER, TOOLS, new byte[0]);
+        assertEquals("MCP Resources content does not exist",
+            assertThrows(NacosException.class, () -> service.load(descriptor)).getErrMsg());
+    }
+    
+    @Test
+    void testLoadWrapsInvalidDescriptorAndProviderFailures() {
+        McpVersionStorageDescriptor invalid = descriptor(false, false);
+        invalid.setServerKey("invalid");
+        NacosException descriptorFailure = assertThrows(NacosException.class,
+            () -> service.load(invalid));
+        assertEquals("Invalid MCP Version storage descriptor", descriptorFailure.getErrMsg());
+        when(storageRouter.route(any(StorageKey.class)))
+            .thenThrow(new IllegalStateException("missing"));
+        NacosException providerFailure = assertThrows(NacosException.class,
+            () -> service.load(descriptor(false, false)));
+        assertTrue(providerFailure.getErrMsg().contains("provider is unavailable"));
+    }
+    
+    @Test
+    void testLoadWrapsProviderKeyRejectionAndPropagatesStorageFailure() throws Exception {
+        givenStorage();
+        when(storage.get(any(StorageKey.class))).thenThrow(new IllegalArgumentException("bad key"));
+        NacosException invalidKey = assertThrows(NacosException.class,
+            () -> service.load(descriptor(false, false)));
+        assertEquals("Invalid MCP Version storage key", invalidKey.getErrMsg());
+        NacosException expected = new NacosException(NacosException.SERVER_ERROR, "read failed");
+        when(storage.get(any(StorageKey.class))).thenThrow(expected);
+        assertEquals(expected,
+            assertThrows(NacosException.class, () -> service.load(descriptor(false, false))));
+    }
+    
+    @Test
+    void testDeleteAttemptsEveryObjectInReverseDependencyOrder() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(true, true);
+        NacosException resourceFailure =
+            new NacosException(NacosException.SERVER_ERROR, "resource failed");
+        doAnswer(invocation -> {
+            StorageKey key = invocation.getArgument(0);
+            if (descriptor.getResourceKey().equals(key.getKey())) {
+                throw resourceFailure;
+            }
+            if (descriptor.getToolKey().equals(key.getKey())) {
+                throw new IllegalArgumentException("tool key rejected");
+            }
+            return null;
+        }).when(storage).delete(any(StorageKey.class));
+        
+        NacosException result = assertThrows(NacosException.class,
+            () -> service.delete(descriptor));
+        
+        assertEquals(resourceFailure, result);
+        assertEquals(1, result.getSuppressed().length);
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage, times(3)).delete(keyCaptor.capture());
+        assertEquals(List.of(descriptor.getResourceKey(), descriptor.getToolKey(),
+            descriptor.getServerKey()), keys(keyCaptor));
+    }
+    
+    @Test
+    void testDeleteSupportsMissingOptionalFiles() throws Exception {
+        givenStorage();
+        McpVersionStorageDescriptor descriptor = descriptor(false, false);
+        service.delete(descriptor);
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage).delete(keyCaptor.capture());
+        assertEquals(descriptor.getServerKey(), keyCaptor.getValue().getKey());
+    }
+    
+    @Test
+    void testDeleteRejectsInvalidDescriptorBeforeRouting() {
+        McpVersionStorageDescriptor descriptor = descriptor(false, false);
+        descriptor.setSchemaVersion(2);
+        assertThrows(NacosException.class, () -> service.delete(descriptor));
+        verify(storageRouter, never()).route(any(StorageKey.class));
+    }
+    
+    @Test
+    void testContentsAreValidatedAndDefensivelyCopied() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new McpVersionStorageContents(null, null, null));
+        assertThrows(IllegalArgumentException.class,
+            () -> new McpVersionStorageContents(new byte[0], null, null));
+        assertThrows(IllegalArgumentException.class,
+            () -> new McpVersionStorageContents(SERVER, new byte[0], null));
+        assertThrows(IllegalArgumentException.class,
+            () -> new McpVersionStorageContents(SERVER, null, new byte[0]));
+        byte[] source = SERVER.clone();
+        McpVersionStorageContents contents = new McpVersionStorageContents(source, null, null);
+        source[0] = 'x';
+        assertArrayEquals(SERVER, contents.getServerContent());
+        byte[] returned = contents.getServerContent();
+        returned[0] = 'y';
+        assertArrayEquals(SERVER, contents.getServerContent());
+    }
+    
+    private void givenStorage() {
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+    }
+    
+    private McpVersionStorageDescriptor descriptor(boolean tools, boolean resources) {
+        return McpVersionStorageKeyComposer.compose("public", MCP_ID, "1.0.0", tools, resources);
+    }
+    
+    private McpVersionStorageContents contents(boolean tools, boolean resources) {
+        return new McpVersionStorageContents(SERVER, tools ? TOOLS : null,
+            resources ? RESOURCES : null);
+    }
+    
+    private byte[] contentFor(McpVersionStorageDescriptor descriptor, StorageKey key) {
+        if (descriptor.getServerKey().equals(key.getKey())) {
+            return SERVER;
+        }
+        if (descriptor.getToolKey().equals(key.getKey())) {
+            return TOOLS;
+        }
+        return RESOURCES;
+    }
+    
+    private List<String> keys(ArgumentCaptor<StorageKey> captor) {
+        return captor.getAllValues().stream().map(StorageKey::getKey).toList();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
@@ -111,6 +111,81 @@ class NacosConfigAiResourceStorageTest {
     }
     
     @Test
+    void testParseAllowlistedMcpKeysPreservesExistingCoordinates() {
+        List<String[]> coordinates = Arrays.asList(
+            new String[] {"mcp-server", "id-version:build-mcp-server.json"},
+            new String[] {"mcp-tools", "id-version:build-mcp-tools.json"},
+            new String[] {"mcp-resources", "id-version:build-mcp-resources.json"});
+        for (String[] coordinate : coordinates) {
+            StorageKey key = new StorageKey(NacosConfigAiResourceStorage.TYPE,
+                "public:" + coordinate[0] + ':' + coordinate[1]);
+            NacosConfigAiResourceStorage.KeyParts parts =
+                NacosConfigAiResourceStorage.parse(key);
+            assertEquals("public", parts.namespaceId());
+            assertEquals(coordinate[0], parts.group());
+            assertEquals(coordinate[1], parts.dataId());
+        }
+    }
+    
+    @Test
+    void testMcpStorageOperationsDoNotEncodePhysicalCoordinate() throws Exception {
+        NacosConfigAiResourceStorage storageWithoutSync =
+            new NacosConfigAiResourceStorage(configQueryChainService, configOperationService, null);
+        String dataId = "id-version:build-mcp-server.json";
+        StorageKey key = new StorageKey(NacosConfigAiResourceStorage.TYPE,
+            "public:mcp-server:" + dataId);
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        response.setContent("content");
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+        
+        storageWithoutSync.save(key, "content".getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals("content".getBytes(StandardCharsets.UTF_8), storageWithoutSync.get(key));
+        storageWithoutSync.delete(key);
+        
+        ArgumentCaptor<ConfigForm> formCaptor = ArgumentCaptor.forClass(ConfigForm.class);
+        verify(configOperationService).publishConfig(formCaptor.capture(), any(), isNull());
+        assertEquals(dataId, formCaptor.getValue().getDataId());
+        assertEquals("mcp-server", formCaptor.getValue().getGroup());
+        ArgumentCaptor<ConfigQueryChainRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigQueryChainRequest.class);
+        verify(configQueryChainService).handle(requestCaptor.capture());
+        assertEquals(dataId, requestCaptor.getValue().getDataId());
+        assertEquals("mcp-server", requestCaptor.getValue().getGroup());
+        verify(configOperationService).deleteConfig(dataId, "mcp-server", "public", null, null,
+            "nacos", null);
+    }
+    
+    @Test
+    void testRejectMcpLikeKeysOutsideAllowlistOrSuffixContract() {
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE, "public:user-group:file.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE, "public:mcp-server:wrong.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE, ":mcp-tools:id-mcp-tools.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE, "public:mcp-resources:")));
+    }
+    
+    @Test
+    void testMcpGroupTokensDoNotBreakLegacySkillNames() {
+        for (String skillName : Arrays.asList("mcp-server", "mcp-tools", "mcp-resources")) {
+            StorageKey key = NacosConfigAiResourceStorage.buildStorageKey(
+                NacosConfigAiResourceStorage.TYPE, "public", skillName, "1.0.0", "skill.json");
+            NacosConfigAiResourceStorage.KeyParts parts =
+                NacosConfigAiResourceStorage.parse(key);
+            assertEquals(SkillUtils.buildSkillVersionGroup(skillName, "1.0.0"), parts.group());
+            assertEquals("skill.json", parts.dataId());
+        }
+    }
+    
+    @Test
     void testBuildAgentVersionStorageKeyRejectsInvalidCoordinates() {
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionStorageKeyComposer.compose(


### PR DESCRIPTION
## What is the purpose of the change

For #15761.

Implement the storage foundation defined by the MCP AI Resource lifecycle hosting specs merged in #15773. This PR adds only internal mapping, storage, and identity-resolution capabilities; it does not switch management traffic or change the existing MCP serving plane, HTTP APIs, gRPC APIs, or SDK contracts.

## Brief changelog

- Add strict schema-v1 serializers for MCP Resource ext and Version storage descriptors.
- Compose and validate logical keys for the existing Server, Tools, and Resources Config coordinates.
- Route MCP Version content through `AiResourceStorageRouter` while preserving the historical physical coordinates and bytes.
- Encapsulate the historical serving Manifest Config access in `McpServingManifestStorage`.
- Resolve canonical MCP Resources by name or deprecated `mcpId` using `ai_resource` rows only, including duplicate and corruption detection.
- Add focused unit tests for serialization, key compatibility, storage ordering/failure handling, Manifest access, and paged legacy-ID lookup.

## Verifying this change

- `mvn -pl ai spotless:apply`
- `mvn -pl ai spotless:check`
- Focused MCP/storage suite: 89 tests passed.
- `mvn -pl ai -DskipTests compile checkstyle:check spotbugs:check apache-rat:check spotless:check`
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests` (62-module reactor passed).
- The full `ai` unit-test run exposed two order-sensitive failures in the untouched `OpenAiCompatibleResourceIndexEnhancementServiceTest`; its isolated rerun passed 7/7. The changed focused suite is clean and does not mutate those system properties.

No OpenAPI or Java/Maintainer SDK IT matrix changes are needed because this PR changes no external API or SDK contract.

* [x] A GitHub issue is filed and this PR addresses only that issue.
* [x] The title follows the issue format and the commit has a meaningful subject/body.
* [x] The description documents the scope, compatibility boundary, and verification.
* [x] Unit tests cover the new internal behavior.
* [x] Spotless and the repository pre-submission gate pass.