### PR TITLE
[ISSUE #15761] Reconcile historical MCP lifecycle resources

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTask.java
@@ -1,0 +1,565 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.service.mcp.McpHistoricalResourceReconciler;
+import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.response.Namespace;
+import com.alibaba.nacos.common.executor.ExecutorFactory;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.common.utils.ThreadFactoryBuilder;
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.core.service.NamespaceOperationService;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Periodically reconciles historical MCP serving data into AI Resource lifecycle rows.
+ *
+ * <p>The task remains in {@code SYNCING}. It persists diagnostic progress and uses a renewable
+ * Config lease, but deliberately does not delete lifecycle rows, write the permanent
+ * {@code LIFECYCLE_MANAGED} marker, or switch any management route.</p>
+ *
+ * @author Nacos
+ */
+@Component
+public class McpLifecycleReconciliationTask
+    implements ApplicationListener<ApplicationReadyEvent>, DisposableBean {
+    
+    static final String RECONCILIATION_ENABLED_KEY =
+        "nacos.ai.mcp.resource.reconciliation.enabled";
+    
+    static final String RECONCILIATION_INTERVAL_SECONDS_KEY =
+        "nacos.ai.mcp.resource.reconciliation.interval-seconds";
+    
+    static final String RECONCILIATION_LEASE_DATA_ID =
+        "nacos.ai.mcp.resource.reconciliation.lease.v1";
+    
+    static final String RECONCILIATION_PROGRESS_DATA_ID =
+        "nacos.ai.mcp.resource.reconciliation.progress.v1";
+    
+    static final String INTERNAL_GROUP = "nacos_internal";
+    
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(McpLifecycleReconciliationTask.class);
+    
+    private static final int SCAN_PAGE_SIZE = 100;
+    
+    private static final long DEFAULT_RECONCILIATION_INTERVAL_SECONDS = 300L;
+    
+    private static final long LEASE_DURATION_MILLIS = 10 * 60 * 1000L;
+    
+    private static final long LEASE_RENEW_MILLIS = LEASE_DURATION_MILLIS / 3;
+    
+    private static final int MAX_LAST_ERROR_LENGTH = 2048;
+    
+    private static final String STATE_SYNCING = "SYNCING";
+    
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    
+    private final ScheduledExecutorService reconciliationExecutor =
+        ExecutorFactory.Managed.newSingleScheduledExecutorService(
+            McpLifecycleReconciliationTask.class.getCanonicalName() + ".scan",
+            new ThreadFactoryBuilder().daemon(true)
+                .nameFormat("nacos-ai-mcp-resource-reconcile-%d").build());
+    
+    private final ScheduledExecutorService leaseExecutor =
+        ExecutorFactory.Managed.newSingleScheduledExecutorService(
+            McpLifecycleReconciliationTask.class.getCanonicalName() + ".lease",
+            new ThreadFactoryBuilder().daemon(true)
+                .nameFormat("nacos-ai-mcp-resource-reconcile-lease-%d").build());
+    
+    private final NamespaceOperationService namespaceOperationService;
+    
+    private final McpServingManifestStorage manifestStorage;
+    
+    private final McpHistoricalResourceReconciler reconciler;
+    
+    private final AiResourcePersistService resourcePersistService;
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    private final ConfigOperationService configOperationService;
+    
+    public McpLifecycleReconciliationTask(NamespaceOperationService namespaceOperationService,
+        McpServingManifestStorage manifestStorage,
+        McpHistoricalResourceReconciler reconciler,
+        AiResourcePersistService resourcePersistService,
+        ConfigQueryChainService configQueryChainService,
+        ConfigOperationService configOperationService) {
+        this.namespaceOperationService = namespaceOperationService;
+        this.manifestStorage = manifestStorage;
+        this.reconciler = reconciler;
+        this.resourcePersistService = resourcePersistService;
+        this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+    }
+    
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (event.getApplicationContext().getParent() != null) {
+            return;
+        }
+        if (!initialized.compareAndSet(false, true)) {
+            return;
+        }
+        if (!Boolean.parseBoolean(EnvUtil.getProperty(RECONCILIATION_ENABLED_KEY, "true"))) {
+            LOGGER.info("MCP lifecycle reconciliation is disabled via {}",
+                RECONCILIATION_ENABLED_KEY);
+            return;
+        }
+        long intervalSeconds = positiveLong(RECONCILIATION_INTERVAL_SECONDS_KEY,
+            DEFAULT_RECONCILIATION_INTERVAL_SECONDS);
+        reconciliationExecutor.scheduleWithFixedDelay(this::executeReconciliation, 0L,
+            intervalSeconds, TimeUnit.SECONDS);
+    }
+    
+    void executeReconciliation() {
+        ReconciliationLease lease = tryAcquireLease();
+        if (lease == null) {
+            LOGGER.debug("Skip MCP lifecycle reconciliation because another node owns the lease");
+            return;
+        }
+        ReconciliationStats stats = new ReconciliationStats();
+        stats.generation = UUID.randomUUID().toString();
+        stats.startedAt = System.currentTimeMillis();
+        try {
+            NamespaceScan namespaceScan = getNamespaces();
+            stats.complete = namespaceScan.complete;
+            if (!namespaceScan.complete) {
+                stats.recordFailure("Namespace listing was incomplete");
+            }
+            for (String namespaceId : namespaceScan.namespaceIds) {
+                lease.assertOwned();
+                reconcileNamespace(namespaceId, lease, stats);
+                stats.namespaces++;
+            }
+            lease.assertOwned();
+        } catch (Exception e) {
+            stats.recordFailure(e.getMessage());
+            LOGGER.error("MCP lifecycle reconciliation failed unexpectedly", e);
+        } finally {
+            stats.completedAt = System.currentTimeMillis();
+            if (lease.isOwned()) {
+                persistProgress(stats);
+            }
+            lease.close();
+            LOGGER.info(
+                "MCP lifecycle reconciliation completed: generation={}, namespaces={}, "
+                    + "manifests={}, changed={}, orphaned={}, failed={}, zeroDifference={}",
+                stats.generation, stats.namespaces, stats.manifests, stats.changed,
+                stats.orphaned, stats.failed, stats.zeroDifference());
+        }
+    }
+    
+    private void reconcileNamespace(String namespaceId, ReconciliationLease lease,
+        ReconciliationStats stats) throws Exception {
+        Set<String> manifestNames = new LinkedHashSet<>();
+        Map<String, String> idsByName = new HashMap<>();
+        Map<String, String> namesById = new HashMap<>();
+        int pageNo = 1;
+        int pagesAvailable = 1;
+        while (pageNo <= pagesAvailable) {
+            lease.assertOwned();
+            Page<McpServerVersionInfo> page = manifestStorage.list(namespaceId, pageNo,
+                SCAN_PAGE_SIZE);
+            pagesAvailable = resolvePages(page, pageNo, SCAN_PAGE_SIZE);
+            for (McpServerVersionInfo manifest : page.getPageItems()) {
+                lease.assertOwned();
+                stats.manifests++;
+                manifestNames.add(manifest.getName());
+                String previousId = idsByName.putIfAbsent(manifest.getName(), manifest.getId());
+                String previousName = namesById.putIfAbsent(manifest.getId(), manifest.getName());
+                if (previousId != null || previousName != null) {
+                    stats.recordFailure("Duplicate historical MCP identity in namespace "
+                        + namespaceId + ": " + manifest.getName() + '/' + manifest.getId());
+                    continue;
+                }
+                try {
+                    stats.changed += reconciler.reconcile(namespaceId, manifest);
+                } catch (Exception e) {
+                    stats.recordFailure("Failed to reconcile MCP " + manifest.getName()
+                        + " in namespace " + namespaceId + ": " + e.getMessage());
+                    LOGGER.warn("Failed to reconcile historical MCP {} in namespace {}",
+                        manifest.getName(), namespaceId, e);
+                }
+            }
+            pageNo++;
+        }
+        detectOrphans(namespaceId, manifestNames, lease, stats);
+    }
+    
+    private void detectOrphans(String namespaceId, Set<String> manifestNames,
+        ReconciliationLease lease, ReconciliationStats stats) {
+        QueryCondition condition = new QueryCondition();
+        condition.setNamespaceId(namespaceId);
+        condition.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        int pageNo = 1;
+        int pagesAvailable = 1;
+        while (pageNo <= pagesAvailable) {
+            lease.assertOwned();
+            Page<AiResource> page = resourcePersistService.list(condition, pageNo,
+                SCAN_PAGE_SIZE);
+            if (page == null || page.getPageItems() == null) {
+                throw new IllegalStateException(
+                    "Unable to page MCP Resource rows for orphan detection");
+            }
+            pagesAvailable = resolvePages(page, pageNo, SCAN_PAGE_SIZE);
+            collectOrphans(namespaceId, manifestNames, page.getPageItems(), stats);
+            pageNo++;
+        }
+    }
+    
+    private void collectOrphans(String namespaceId, Set<String> manifestNames,
+        Collection<AiResource> resources, ReconciliationStats stats) {
+        for (AiResource resource : resources) {
+            if (resource == null || !namespaceId.equals(resource.getNamespaceId())
+                || !AiResourceConstants.RESOURCE_TYPE_MCP.equals(resource.getType())
+                || StringUtils.isBlank(resource.getName())) {
+                throw new IllegalStateException(
+                    "MCP Resource scan returned an inconsistent row in namespace " + namespaceId);
+            }
+            if (McpHistoricalResourceReconciler.LEGACY_SOURCE.equals(resource.getFrom())
+                && !manifestNames.contains(resource.getName())) {
+                stats.orphaned++;
+                stats.recordFailure("Historical MCP Resource has no serving Manifest: "
+                    + namespaceId + '/' + resource.getName());
+            }
+        }
+    }
+    
+    private NamespaceScan getNamespaces() {
+        try {
+            List<Namespace> namespaces = namespaceOperationService.getNamespaceList();
+            if (namespaces != null && !namespaces.isEmpty()) {
+                List<String> namespaceIds = namespaces.stream().filter(Objects::nonNull)
+                    .map(Namespace::getNamespace).filter(StringUtils::isNotBlank).distinct()
+                    .sorted(Comparator.naturalOrder()).toList();
+                if (!namespaceIds.isEmpty()) {
+                    return new NamespaceScan(namespaceIds, true);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to list namespaces for MCP lifecycle reconciliation", e);
+        }
+        List<String> fallback = new ArrayList<>(1);
+        fallback.add(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+        return new NamespaceScan(fallback, false);
+    }
+    
+    private int resolvePages(Page<?> page, int pageNo, int pageSize) {
+        if (page == null || page.getPageItems() == null) {
+            throw new IllegalStateException("MCP reconciliation received an empty page");
+        }
+        if (page.getPagesAvailable() > 0) {
+            return Math.max(pageNo, page.getPagesAvailable());
+        }
+        int calculated = (page.getTotalCount() + pageSize - 1) / pageSize;
+        return Math.max(pageNo, calculated);
+    }
+    
+    private long positiveLong(String key, long defaultValue) {
+        try {
+            long value = Long.parseLong(EnvUtil.getProperty(key, String.valueOf(defaultValue)));
+            return value > 0 ? value : defaultValue;
+        } catch (Exception ignored) {
+            return defaultValue;
+        }
+    }
+    
+    private ReconciliationLease tryAcquireLease() {
+        String owner = UUID.randomUUID().toString();
+        String content = leaseContent(owner);
+        LeaseRecord current = readLease();
+        if (current == null) {
+            try {
+                publishLease(content, false, null);
+                return new ReconciliationLease(owner, contentMd5(content));
+            } catch (ConfigAlreadyExistsException e) {
+                return null;
+            } catch (Exception e) {
+                LOGGER.error("Failed to create MCP lifecycle reconciliation lease", e);
+                return null;
+            }
+        }
+        if (!current.expired() || StringUtils.isBlank(current.md5)) {
+            return null;
+        }
+        try {
+            publishLease(content, true, current.md5);
+            LOGGER.info("Took over expired MCP lifecycle reconciliation lease");
+            return new ReconciliationLease(owner, contentMd5(content));
+        } catch (Exception e) {
+            LOGGER.debug("MCP lifecycle reconciliation lease was taken by another node");
+            return null;
+        }
+    }
+    
+    private LeaseRecord readLease() {
+        try {
+            ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(
+                RECONCILIATION_LEASE_DATA_ID, INTERNAL_GROUP,
+                com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+            ConfigQueryChainResponse response = configQueryChainService.handle(request);
+            if (response == null
+                || response
+                    .getStatus() == ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND
+                || StringUtils.isBlank(response.getContent())) {
+                return null;
+            }
+            if (!McpConfigUtils.isConfigFound(response.getStatus())) {
+                LOGGER.warn("Unable to inspect MCP lifecycle reconciliation lease: {}",
+                    response.getMessage());
+                return null;
+            }
+            return LeaseRecord.parse(response.getContent(), response.getMd5());
+        } catch (Exception e) {
+            LOGGER.warn("Failed to inspect MCP lifecycle reconciliation lease", e);
+            return null;
+        }
+    }
+    
+    private void persistProgress(ReconciliationStats stats) {
+        try {
+            Map<String, Object> progress = new LinkedHashMap<>();
+            progress.put("schemaVersion", 1);
+            progress.put("state", STATE_SYNCING);
+            progress.put("generation", stats.generation);
+            progress.put("startedAt", stats.startedAt);
+            progress.put("completedAt", stats.completedAt);
+            progress.put("namespaces", stats.namespaces);
+            progress.put("manifests", stats.manifests);
+            progress.put("changed", stats.changed);
+            progress.put("orphaned", stats.orphaned);
+            progress.put("failed", stats.failed);
+            progress.put("completeNamespaceScan", stats.complete);
+            progress.put("zeroDifference", stats.zeroDifference());
+            progress.put("searchBackfillPending", true);
+            progress.put("managedCutoverReady", false);
+            if (StringUtils.isNotBlank(stats.lastError)) {
+                progress.put("lastError", stats.lastError);
+            }
+            ConfigForm form = internalForm(RECONCILIATION_PROGRESS_DATA_ID,
+                JacksonUtils.toJson(progress));
+            form.setType(ConfigType.JSON.getType());
+            ConfigRequestInfo requestInfo = new ConfigRequestInfo();
+            requestInfo.setUpdateForExist(true);
+            configOperationService.publishConfig(form, requestInfo, null);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to persist MCP lifecycle reconciliation progress", e);
+        }
+    }
+    
+    private void publishLease(String content, boolean updateForExist, String casMd5)
+        throws Exception {
+        ConfigRequestInfo requestInfo = new ConfigRequestInfo();
+        requestInfo.setUpdateForExist(updateForExist);
+        requestInfo.setCasMd5(casMd5);
+        configOperationService.publishConfig(
+            internalForm(RECONCILIATION_LEASE_DATA_ID, content), requestInfo, null);
+    }
+    
+    private ConfigForm internalForm(String dataId, String content) {
+        ConfigForm result = new ConfigForm();
+        result.setNamespaceId(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+        result.setGroup(INTERNAL_GROUP);
+        result.setDataId(dataId);
+        result.setContent(content);
+        result.setSrcUser("nacos");
+        return result;
+    }
+    
+    private String leaseContent(String owner) {
+        return owner + '|' + (System.currentTimeMillis() + LEASE_DURATION_MILLIS);
+    }
+    
+    private String contentMd5(String content) {
+        return MD5Utils.md5Hex(content, com.alibaba.nacos.api.common.Constants.ENCODE);
+    }
+    
+    @Override
+    public void destroy() {
+        reconciliationExecutor.shutdownNow();
+        leaseExecutor.shutdownNow();
+    }
+    
+    private static final class NamespaceScan {
+        
+        private final List<String> namespaceIds;
+        
+        private final boolean complete;
+        
+        private NamespaceScan(List<String> namespaceIds, boolean complete) {
+            this.namespaceIds = namespaceIds;
+            this.complete = complete;
+        }
+    }
+    
+    private static final class ReconciliationStats {
+        
+        private String generation;
+        
+        private long startedAt;
+        
+        private long completedAt;
+        
+        private int namespaces;
+        
+        private int manifests;
+        
+        private int changed;
+        
+        private int orphaned;
+        
+        private int failed;
+        
+        private boolean complete;
+        
+        private String lastError;
+        
+        private void recordFailure(String error) {
+            failed++;
+            complete = false;
+            if (StringUtils.isBlank(error)) {
+                return;
+            }
+            lastError = error.length() <= MAX_LAST_ERROR_LENGTH ? error
+                : error.substring(0, MAX_LAST_ERROR_LENGTH);
+        }
+        
+        private boolean zeroDifference() {
+            return complete && changed == 0 && orphaned == 0 && failed == 0;
+        }
+    }
+    
+    private final class ReconciliationLease implements AutoCloseable {
+        
+        private final String owner;
+        
+        private final AtomicBoolean owned = new AtomicBoolean(true);
+        
+        private final ScheduledFuture<?> renewal;
+        
+        private String currentMd5;
+        
+        private ReconciliationLease(String owner, String currentMd5) {
+            this.owner = owner;
+            this.currentMd5 = currentMd5;
+            renewal = leaseExecutor.scheduleWithFixedDelay(this::renewSafely,
+                LEASE_RENEW_MILLIS, LEASE_RENEW_MILLIS, TimeUnit.MILLISECONDS);
+        }
+        
+        private void assertOwned() {
+            if (!owned.get()) {
+                throw new IllegalStateException("MCP lifecycle reconciliation lease was lost");
+            }
+        }
+        
+        private boolean isOwned() {
+            return owned.get();
+        }
+        
+        private synchronized void renewSafely() {
+            if (!owned.get()) {
+                return;
+            }
+            try {
+                String content = leaseContent(owner);
+                publishLease(content, true, currentMd5);
+                currentMd5 = contentMd5(content);
+            } catch (Exception e) {
+                owned.set(false);
+                LOGGER.warn("Failed to renew MCP lifecycle reconciliation lease", e);
+            }
+        }
+        
+        @Override
+        public synchronized void close() {
+            renewal.cancel(false);
+            if (!owned.compareAndSet(true, false)) {
+                return;
+            }
+            try {
+                publishLease(owner + "|0", true, currentMd5);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to release MCP lifecycle reconciliation lease", e);
+            }
+        }
+    }
+    
+    private static final class LeaseRecord {
+        
+        private final long expireAt;
+        
+        private final String md5;
+        
+        private LeaseRecord(long expireAt, String md5) {
+            this.expireAt = expireAt;
+            this.md5 = md5;
+        }
+        
+        private boolean expired() {
+            return expireAt <= System.currentTimeMillis();
+        }
+        
+        private static LeaseRecord parse(String content, String md5) {
+            String value = content.trim();
+            int separator = value.lastIndexOf('|');
+            if (separator <= 0 || separator == value.length() - 1) {
+                throw new IllegalArgumentException("Invalid MCP reconciliation lease content");
+            }
+            return new LeaseRecord(Long.parseLong(value.substring(separator + 1)), md5);
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTask.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.AiResourceConstants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.service.mcp.McpHistoricalResourceReconciler;
 import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage;
+import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage.ReconciliationPage;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.utils.McpConfigUtils;
@@ -208,13 +209,21 @@ public class McpLifecycleReconciliationTask
         Set<String> manifestNames = new LinkedHashSet<>();
         Map<String, String> idsByName = new HashMap<>();
         Map<String, String> namesById = new HashMap<>();
+        boolean manifestScanComplete = true;
         int pageNo = 1;
         int pagesAvailable = 1;
         while (pageNo <= pagesAvailable) {
             lease.assertOwned();
-            Page<McpServerVersionInfo> page = manifestStorage.list(namespaceId, pageNo,
+            ReconciliationPage page = manifestStorage.list(namespaceId, pageNo,
                 SCAN_PAGE_SIZE);
             pagesAvailable = resolvePages(page, pageNo, SCAN_PAGE_SIZE);
+            if (!page.getFailures().isEmpty()) {
+                manifestScanComplete = false;
+                for (String failure : page.getFailures()) {
+                    stats.recordFailure(failure);
+                    LOGGER.warn("{}", failure);
+                }
+            }
             for (McpServerVersionInfo manifest : page.getPageItems()) {
                 lease.assertOwned();
                 stats.manifests++;
@@ -237,7 +246,12 @@ public class McpLifecycleReconciliationTask
             }
             pageNo++;
         }
-        detectOrphans(namespaceId, manifestNames, lease, stats);
+        if (manifestScanComplete) {
+            detectOrphans(namespaceId, manifestNames, lease, stats);
+        } else {
+            LOGGER.warn("Skip MCP orphan detection in namespace {} because the historical "
+                + "Manifest scan was incomplete", namespaceId);
+        }
     }
     
     private void detectOrphans(String namespaceId, Set<String> manifestNames,

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconciler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconciler.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.ai.model.mcp.McpServerStorageInfo;
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.ai.service.mcp.storage.McpResourceExtSerializer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageContents;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageDescriptorSerializer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageKeyComposer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageService;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Reconciles one historical MCP serving Manifest into AI Resource lifecycle rows.
+ *
+ * <p>Historical content is loaded and validated through MCP Version Storage, then referenced by
+ * descriptor. This service never saves payload bytes or mutates Naming. Version rows are made
+ * equivalent first and the Resource row is inserted or updated last.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class McpHistoricalResourceReconciler {
+    
+    public static final String LEGACY_SOURCE = "legacy-mcp";
+    
+    private static final String OWNER_NACOS = "nacos";
+    
+    private static final String RESOURCE_NAME_FIELD = "name";
+    
+    private static final int EXACT_RESOURCE_PAGE_SIZE = 2;
+    
+    private static final int VERSION_PAGE_SIZE = 100;
+    
+    private static final int MAX_RESOURCE_NAME_LENGTH = 256;
+    
+    private static final int MAX_RESOURCE_DESCRIPTION_LENGTH = 2048;
+    
+    private static final int MAX_VERSION_LENGTH = 64;
+    
+    private final McpVersionStorageService versionStorageService;
+    
+    private final AiResourcePersistService resourcePersistService;
+    
+    private final AiResourceVersionPersistService versionPersistService;
+    
+    public McpHistoricalResourceReconciler(McpVersionStorageService versionStorageService,
+        AiResourcePersistService resourcePersistService,
+        AiResourceVersionPersistService versionPersistService) {
+        this.versionStorageService = versionStorageService;
+        this.resourcePersistService = resourcePersistService;
+        this.versionPersistService = versionPersistService;
+    }
+    
+    /**
+     * Reconcile one historical MCP resource.
+     *
+     * @param namespaceId namespace identifier
+     * @param manifest historical serving Manifest
+     * @return number of Resource or Version rows changed; zero means already equivalent
+     * @throws NacosException when historical content is invalid, missing, or conflicts with rows
+     */
+    public int reconcile(String namespaceId, McpServerVersionInfo manifest)
+        throws NacosException {
+        ManifestIdentity identity = validateManifest(namespaceId, manifest);
+        List<AiResourceVersion> expectedVersions = prepareVersions(identity, manifest);
+        AiResource expectedResource = buildResource(identity, manifest, expectedVersions.size());
+        AiResource existingResource = preflightResource(expectedResource);
+        VersionPreflight versionPreflight = preflightVersions(identity, expectedVersions);
+        if (!versionPreflight.extraVersions.isEmpty()) {
+            throw conflict("Historical MCP Version rows exist outside the Manifest for "
+                + identity.name + ": " + versionPreflight.extraVersions, null);
+        }
+        
+        int changes = 0;
+        for (AiResourceVersion missing : versionPreflight.missingVersions) {
+            changes += insertVersionOrRecover(missing);
+        }
+        changes += upsertResourceLast(expectedResource, existingResource);
+        return changes;
+    }
+    
+    private ManifestIdentity validateManifest(String namespaceId, McpServerVersionInfo manifest)
+        throws NacosException {
+        try {
+            AgentValidationUtils.validateNamespaceId(namespaceId);
+            if (manifest == null) {
+                throw new IllegalArgumentException("MCP serving Manifest must not be null");
+            }
+            McpResourceExtSerializer.validateMcpId(manifest.getId());
+            if (StringUtils.isBlank(manifest.getName())
+                || manifest.getName().length() > MAX_RESOURCE_NAME_LENGTH) {
+                throw new IllegalArgumentException("Invalid historical MCP Resource name");
+            }
+            if (manifest.getDescription() != null
+                && manifest.getDescription().length() > MAX_RESOURCE_DESCRIPTION_LENGTH) {
+                throw new IllegalArgumentException("Historical MCP description is too long");
+            }
+            if (manifest.getVersionDetails() == null
+                || manifest.getVersionDetails().isEmpty()) {
+                throw new IllegalArgumentException("Historical MCP Manifest has no Versions");
+            }
+            Set<String> versions = new HashSet<>();
+            for (ServerVersionDetail detail : manifest.getVersionDetails()) {
+                String version = detail == null ? null : detail.getVersion();
+                validateVersion(version);
+                if (!versions.add(version)) {
+                    throw new IllegalArgumentException(
+                        "Historical MCP Manifest has duplicate Version " + version);
+                }
+            }
+            if (StringUtils.isBlank(manifest.getLatestPublishedVersion())
+                || !versions.contains(manifest.getLatestPublishedVersion())) {
+                throw new IllegalArgumentException(
+                    "Historical MCP latest Version is absent from the Manifest");
+            }
+            return new ManifestIdentity(namespaceId, manifest.getName(), manifest.getId());
+        } catch (IllegalArgumentException e) {
+            throw conflict("Invalid historical MCP serving Manifest", e);
+        }
+    }
+    
+    private List<AiResourceVersion> prepareVersions(ManifestIdentity identity,
+        McpServerVersionInfo manifest) throws NacosException {
+        List<AiResourceVersion> result = new ArrayList<>(manifest.getVersionDetails().size());
+        for (ServerVersionDetail detail : manifest.getVersionDetails()) {
+            result.add(prepareVersion(identity, detail.getVersion()));
+        }
+        return result;
+    }
+    
+    private AiResourceVersion prepareVersion(ManifestIdentity identity, String version)
+        throws NacosException {
+        McpVersionStorageDescriptor serverDescriptor = McpVersionStorageKeyComposer.compose(
+            identity.namespaceId, identity.mcpId, version, false, false);
+        McpVersionStorageContents serverOnly = versionStorageService.load(serverDescriptor);
+        McpServerStorageInfo server = decode(serverOnly.getServerContent(),
+            McpServerStorageInfo.class, "Server", identity, version);
+        validateServerIdentity(server, identity, version);
+        
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.fromLegacy(
+            identity.namespaceId, identity.mcpId, version, server);
+        McpVersionStorageContents contents = versionStorageService.load(descriptor);
+        if (!Arrays.equals(serverOnly.getServerContent(), contents.getServerContent())) {
+            throw conflict("Historical MCP Server content changed while reconciling "
+                + identity.name + ':' + version, null);
+        }
+        if (contents.getToolContent() != null) {
+            decode(contents.getToolContent(), McpToolSpecification.class, "Tools", identity,
+                version);
+        }
+        if (contents.getResourceContent() != null) {
+            decode(contents.getResourceContent(), McpResourceSpecification.class, "Resources",
+                identity, version);
+        }
+        
+        AiResourceVersion result = new AiResourceVersion();
+        result.setNamespaceId(identity.namespaceId);
+        result.setName(identity.name);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        result.setVersion(version);
+        result.setStatus(AiResourceConstants.VERSION_STATUS_ONLINE);
+        result.setAuthor(OWNER_NACOS);
+        result.setDesc("");
+        result.setStorage(McpVersionStorageDescriptorSerializer.serialize(descriptor));
+        return result;
+    }
+    
+    private <T> T decode(byte[] content, Class<T> type, String contentName,
+        ManifestIdentity identity, String version) throws NacosException {
+        try {
+            T result = JacksonUtils.toObj(new String(content, StandardCharsets.UTF_8), type);
+            if (result == null) {
+                throw new IllegalArgumentException(contentName + " content is null");
+            }
+            return result;
+        } catch (NacosDeserializationException | IllegalArgumentException e) {
+            throw conflict("Historical MCP " + contentName + " content is invalid for "
+                + identity.name + ':' + version, e);
+        }
+    }
+    
+    private void validateServerIdentity(McpServerStorageInfo server, ManifestIdentity identity,
+        String version) throws NacosException {
+        String versionDetail = server.getVersionDetail() == null ? null
+            : server.getVersionDetail().getVersion();
+        String legacyVersion = server.getVersion();
+        if (StringUtils.isNotBlank(versionDetail) && StringUtils.isNotBlank(legacyVersion)
+            && !versionDetail.equals(legacyVersion)) {
+            throw conflict("Historical MCP Server contains conflicting Version fields for "
+                + identity.name + ':' + version, null);
+        }
+        String actualVersion = StringUtils.isNotBlank(versionDetail) ? versionDetail
+            : legacyVersion;
+        boolean identityMatches = identity.mcpId.equals(server.getId())
+            && identity.name.equals(server.getName()) && version.equals(actualVersion)
+            && (StringUtils.isBlank(server.getNamespaceId())
+                || identity.namespaceId.equals(server.getNamespaceId()));
+        if (!identityMatches) {
+            throw conflict("Historical MCP Server identity does not match its Manifest for "
+                + identity.name + ':' + version, null);
+        }
+    }
+    
+    private AiResource buildResource(ManifestIdentity identity, McpServerVersionInfo manifest,
+        int onlineCount) {
+        McpResourceExt ext = new McpResourceExt();
+        ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        ext.setMcpId(identity.mcpId);
+        
+        ResourceVersionInfo versionInfo = new ResourceVersionInfo();
+        versionInfo.setEditingVersion(null);
+        versionInfo.setReviewingVersion(null);
+        versionInfo.setOnlineCnt(onlineCount);
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put(AiResourceConstants.LABEL_LATEST, manifest.getLatestPublishedVersion());
+        versionInfo.setLabels(labels);
+        
+        AiResource result = new AiResource();
+        result.setNamespaceId(identity.namespaceId);
+        result.setName(identity.name);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        result.setDesc(manifest.getDescription());
+        result.setStatus(manifest.isEnabled() ? AiResourceConstants.META_STATUS_ENABLE
+            : AiResourceConstants.META_STATUS_DISABLE);
+        result.setBizTags("[]");
+        result.setExt(McpResourceExtSerializer.serialize(ext));
+        result.setFrom(LEGACY_SOURCE);
+        result.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        result.setMetaVersion(1L);
+        result.setScope(VisibilityConstants.SCOPE_PUBLIC);
+        result.setOwner(OWNER_NACOS);
+        return result;
+    }
+    
+    private AiResource preflightResource(AiResource expected) throws NacosException {
+        List<AiResource> rows = findResourceRows(expected.getNamespaceId(), expected.getName());
+        if (rows.size() > 1) {
+            throw conflict("Multiple MCP Resource source rows exist for " + expected.getName(),
+                null);
+        }
+        if (rows.isEmpty()) {
+            return null;
+        }
+        AiResource existing = rows.get(0);
+        if (!immutableResourceIdentityMatches(existing, expected)) {
+            throw conflict("Historical MCP Resource conflicts with an existing source row for "
+                + expected.getName(), null);
+        }
+        return existing;
+    }
+    
+    private List<AiResource> findResourceRows(String namespaceId, String name)
+        throws NacosException {
+        QueryCondition condition = new QueryCondition();
+        condition.setNamespaceId(namespaceId);
+        condition.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        condition.putOrGroup(RESOURCE_NAME_FIELD, name);
+        Page<AiResource> page = resourcePersistService.list(condition, 1,
+            EXACT_RESOURCE_PAGE_SIZE);
+        if (page == null || page.getPageItems() == null) {
+            throw storageFailure("Unable to query MCP Resource rows for " + name, null);
+        }
+        List<AiResource> result = page.getPageItems();
+        if (page.getTotalCount() > result.size() || result.size() > EXACT_RESOURCE_PAGE_SIZE) {
+            throw conflict("Multiple MCP Resource source rows exist for " + name, null);
+        }
+        for (AiResource resource : result) {
+            if (resource == null || !namespaceId.equals(resource.getNamespaceId())
+                || !name.equals(resource.getName())
+                || !AiResourceConstants.RESOURCE_TYPE_MCP.equals(resource.getType())) {
+                throw conflict("MCP Resource query returned an inconsistent row for " + name,
+                    null);
+            }
+        }
+        return result;
+    }
+    
+    private VersionPreflight preflightVersions(ManifestIdentity identity,
+        List<AiResourceVersion> expectedVersions) throws NacosException {
+        Map<String, AiResourceVersion> existing = loadExistingVersions(identity);
+        List<AiResourceVersion> missing = new ArrayList<>();
+        for (AiResourceVersion expected : expectedVersions) {
+            AiResourceVersion current = existing.remove(expected.getVersion());
+            if (current == null) {
+                missing.add(expected);
+            } else if (!versionEquivalent(current, expected)) {
+                throw conflict("Historical MCP Version conflicts with an existing row for "
+                    + identity.name + ':' + expected.getVersion(), null);
+            }
+        }
+        return new VersionPreflight(missing, new ArrayList<>(existing.keySet()));
+    }
+    
+    private Map<String, AiResourceVersion> loadExistingVersions(ManifestIdentity identity)
+        throws NacosException {
+        Map<String, AiResourceVersion> result = new LinkedHashMap<>();
+        int pageNo = 1;
+        int pagesAvailable = 1;
+        while (pageNo <= pagesAvailable) {
+            Page<AiResourceVersion> page = versionPersistService.list(identity.namespaceId,
+                identity.name, AiResourceConstants.RESOURCE_TYPE_MCP, null, pageNo,
+                VERSION_PAGE_SIZE);
+            if (page == null || page.getPageItems() == null) {
+                throw storageFailure("Unable to page historical MCP Version rows for "
+                    + identity.name, null);
+            }
+            pagesAvailable = resolvePages(page, pageNo, VERSION_PAGE_SIZE);
+            for (AiResourceVersion version : page.getPageItems()) {
+                if (!versionIdentityMatches(version, identity)
+                    || result.put(version.getVersion(), version) != null) {
+                    throw conflict("Historical MCP Version query returned inconsistent rows for "
+                        + identity.name, null);
+                }
+            }
+            pageNo++;
+        }
+        return result;
+    }
+    
+    private int resolvePages(Page<?> page, int pageNo, int pageSize) {
+        if (page.getPagesAvailable() > 0) {
+            return Math.max(pageNo, page.getPagesAvailable());
+        }
+        int calculated = (page.getTotalCount() + pageSize - 1) / pageSize;
+        return Math.max(pageNo, calculated);
+    }
+    
+    private int insertVersionOrRecover(AiResourceVersion expected) throws NacosException {
+        try {
+            versionPersistService.insert(expected);
+            return 1;
+        } catch (RuntimeException e) {
+            AiResourceVersion recovered = versionPersistService.find(expected.getNamespaceId(),
+                expected.getName(), expected.getType(), expected.getVersion());
+            if (recovered != null && versionEquivalent(recovered, expected)) {
+                return 0;
+            }
+            if (recovered != null) {
+                throw conflict("Concurrent MCP Version insert produced conflicting content for "
+                    + expected.getName() + ':' + expected.getVersion(), e);
+            }
+            throw storageFailure("Unable to insert historical MCP Version row for "
+                + expected.getName() + ':' + expected.getVersion(), e);
+        }
+    }
+    
+    private int upsertResourceLast(AiResource expected, AiResource existing)
+        throws NacosException {
+        if (existing == null) {
+            try {
+                resourcePersistService.insert(expected);
+                return 1;
+            } catch (RuntimeException e) {
+                AiResource recovered = uniqueResourceOrNull(expected.getNamespaceId(),
+                    expected.getName());
+                if (recovered != null && resourceEquivalent(recovered, expected)) {
+                    return 0;
+                }
+                if (recovered != null) {
+                    throw conflict("Concurrent MCP Resource insert produced conflicting metadata "
+                        + "for " + expected.getName(), e);
+                }
+                throw storageFailure("Unable to insert historical MCP Resource row for "
+                    + expected.getName(), e);
+            }
+        }
+        if (resourceEquivalent(existing, expected)) {
+            return 0;
+        }
+        if (existing.getMetaVersion() == null) {
+            throw conflict("Historical MCP Resource has no metadata version for "
+                + expected.getName(), null);
+        }
+        if (resourcePersistService.updateMetaCas(expected.getNamespaceId(), expected.getName(),
+            expected.getType(), existing.getMetaVersion(), expected)) {
+            return 1;
+        }
+        AiResource recovered = uniqueResourceOrNull(expected.getNamespaceId(), expected.getName());
+        if (recovered != null && resourceEquivalent(recovered, expected)) {
+            return 0;
+        }
+        throw conflict("Historical MCP Resource changed concurrently for " + expected.getName(),
+            null);
+    }
+    
+    private AiResource uniqueResourceOrNull(String namespaceId, String name)
+        throws NacosException {
+        List<AiResource> rows = findResourceRows(namespaceId, name);
+        if (rows.size() > 1) {
+            throw conflict("Multiple MCP Resource source rows exist for " + name, null);
+        }
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+    
+    private boolean immutableResourceIdentityMatches(AiResource actual, AiResource expected) {
+        if (actual == null || !Objects.equals(actual.getNamespaceId(), expected.getNamespaceId())
+            || !Objects.equals(actual.getName(), expected.getName())
+            || !Objects.equals(actual.getType(), expected.getType())
+            || !Objects.equals(actual.getFrom(), expected.getFrom())
+            || !Objects.equals(actual.getOwner(), expected.getOwner())
+            || !Objects.equals(actual.getScope(), expected.getScope())) {
+            return false;
+        }
+        try {
+            McpResourceExt actualExt = McpResourceExtSerializer.deserialize(actual.getExt());
+            McpResourceExt expectedExt = McpResourceExtSerializer.deserialize(expected.getExt());
+            return Objects.equals(actualExt.getMcpId(), expectedExt.getMcpId());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+    
+    private boolean resourceEquivalent(AiResource actual, AiResource expected) {
+        return immutableResourceIdentityMatches(actual, expected)
+            && Objects.equals(actual.getDesc(), expected.getDesc())
+            && Objects.equals(actual.getStatus(), expected.getStatus())
+            && emptyBizTags(actual.getBizTags()) && versionInfoEquivalent(actual.getVersionInfo(),
+                expected.getVersionInfo());
+    }
+    
+    private boolean emptyBizTags(String json) {
+        try {
+            List<?> tags = JacksonUtils.toObj(json, List.class);
+            return tags != null && tags.isEmpty();
+        } catch (NacosDeserializationException e) {
+            return false;
+        }
+    }
+    
+    private boolean versionInfoEquivalent(String actualJson, String expectedJson) {
+        try {
+            ResourceVersionInfo actual = JacksonUtils.toObj(actualJson,
+                ResourceVersionInfo.class);
+            ResourceVersionInfo expected = JacksonUtils.toObj(expectedJson,
+                ResourceVersionInfo.class);
+            return actual != null && expected != null
+                && Objects.equals(actual.getEditingVersion(), expected.getEditingVersion())
+                && Objects.equals(actual.getReviewingVersion(), expected.getReviewingVersion())
+                && Objects.equals(actual.getOnlineCnt(), expected.getOnlineCnt())
+                && Objects.equals(actual.getLabels(), expected.getLabels());
+        } catch (NacosDeserializationException e) {
+            return false;
+        }
+    }
+    
+    private boolean versionIdentityMatches(AiResourceVersion version,
+        ManifestIdentity identity) {
+        return version != null && identity.namespaceId.equals(version.getNamespaceId())
+            && identity.name.equals(version.getName())
+            && AiResourceConstants.RESOURCE_TYPE_MCP.equals(version.getType())
+            && StringUtils.isNotBlank(version.getVersion());
+    }
+    
+    private boolean versionEquivalent(AiResourceVersion actual, AiResourceVersion expected) {
+        if (!Objects.equals(actual.getNamespaceId(), expected.getNamespaceId())
+            || !Objects.equals(actual.getName(), expected.getName())
+            || !Objects.equals(actual.getType(), expected.getType())
+            || !Objects.equals(actual.getVersion(), expected.getVersion())
+            || !Objects.equals(actual.getStatus(), expected.getStatus())
+            || !Objects.equals(actual.getAuthor(), expected.getAuthor())
+            || !blankEquivalent(actual.getDesc(), expected.getDesc())
+            || StringUtils.isNotBlank(actual.getPublishPipelineInfo())) {
+            return false;
+        }
+        try {
+            String canonicalActual = McpVersionStorageDescriptorSerializer.serialize(
+                McpVersionStorageDescriptorSerializer.deserialize(actual.getStorage()));
+            return canonicalActual.equals(expected.getStorage());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+    
+    private boolean blankEquivalent(String first, String second) {
+        return StringUtils.isBlank(first) && StringUtils.isBlank(second)
+            || Objects.equals(first, second);
+    }
+    
+    private void validateVersion(String version) {
+        if (StringUtils.isBlank(version) || version.length() > MAX_VERSION_LENGTH) {
+            throw new IllegalArgumentException("Invalid historical MCP Version: " + version);
+        }
+    }
+    
+    private NacosException conflict(String message, Throwable cause) {
+        return cause == null ? new NacosException(NacosException.CONFLICT, message)
+            : new NacosException(NacosException.CONFLICT, message, cause);
+    }
+    
+    private NacosException storageFailure(String message, Throwable cause) {
+        return cause == null ? new NacosException(NacosException.SERVER_ERROR, message)
+            : new NacosException(NacosException.SERVER_ERROR, message, cause);
+    }
+    
+    private static final class ManifestIdentity {
+        
+        private final String namespaceId;
+        
+        private final String name;
+        
+        private final String mcpId;
+        
+        private ManifestIdentity(String namespaceId, String name, String mcpId) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.mcpId = mcpId;
+        }
+    }
+    
+    private static final class VersionPreflight {
+        
+        private final List<AiResourceVersion> missingVersions;
+        
+        private final List<String> extraVersions;
+        
+        private VersionPreflight(List<AiResourceVersion> missingVersions,
+            List<String> extraVersions) {
+            this.missingVersions = missingVersions;
+            this.extraVersions = extraVersions;
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupport.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupport.java
@@ -39,7 +39,7 @@ final class McpJsonValidationSupport {
     }
     
     static Object parseSingleValue(String json, String contractName) {
-        if (json == null || json.trim().isEmpty()) {
+        if (json == null) {
             throw new IllegalArgumentException(contractName + " JSON must not be empty");
         }
         validateSingleJsonValue(json, contractName);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
@@ -113,18 +113,21 @@ public class McpServingManifestStorage {
     }
     
     /**
-     * Page historical serving Manifests in one Namespace.
+     * Page historical serving Manifests in one Namespace for lifecycle reconciliation only.
      *
-     * <p>The scan remains encapsulated by Manifest Storage so lifecycle reconciliation never
-     * depends on the process-local MCP index or calls Config persistence directly.</p>
+     * <p>This is a temporary migration scan. It must not be reused for serving queries,
+     * management listing, identity resolution, or other MCP features. The scan remains
+     * encapsulated by Manifest Storage so historical reconciliation never depends on the
+     * process-local MCP index or calls Config persistence directly. Row-level decoding failures
+     * are returned as diagnostics so valid historical Manifests can still be reconciled.</p>
      *
      * @param namespaceId namespace identifier
      * @param pageNo one-based page number
      * @param pageSize positive page size
-     * @return decoded and coordinate-validated Manifests
-     * @throws NacosException when Config paging or decoding fails
+     * @return decoded and coordinate-validated Manifests plus row-level failures
+     * @throws NacosException when Config paging fails
      */
-    public Page<McpServerVersionInfo> list(String namespaceId, int pageNo, int pageSize)
+    public ReconciliationPage list(String namespaceId, int pageNo, int pageSize)
         throws NacosException {
         AgentValidationUtils.validateNamespaceId(namespaceId);
         if (pageNo <= 0 || pageSize <= 0) {
@@ -141,16 +144,28 @@ public class McpServingManifestStorage {
         if (configPage == null || configPage.getPageItems() == null) {
             throw storageFailure("MCP serving Manifest query returned no page", null);
         }
+        ReconciliationPage result = new ReconciliationPage(Collections.emptyList());
         List<McpServerVersionInfo> manifests = new ArrayList<>(configPage.getPageItems().size());
         for (ConfigInfo configInfo : configPage.getPageItems()) {
-            manifests.add(decodeListedManifest(namespaceId, configInfo));
+            try {
+                manifests.add(decodeListedManifest(namespaceId, configInfo));
+            } catch (NacosException e) {
+                result.addFailure(listedManifestFailure(namespaceId, configInfo, e));
+            }
         }
-        Page<McpServerVersionInfo> result = new Page<>();
         result.setPageNumber(pageNo);
         result.setPagesAvailable(configPage.getPagesAvailable());
         result.setTotalCount(configPage.getTotalCount());
         result.setPageItems(manifests);
         return result;
+    }
+    
+    private String listedManifestFailure(String namespaceId, ConfigInfo configInfo,
+        NacosException cause) {
+        String dataId = configInfo == null || StringUtils.isBlank(configInfo.getDataId())
+            ? "<unknown>" : configInfo.getDataId();
+        return "Invalid historical MCP serving Manifest " + namespaceId + '/' + dataId + ": "
+            + cause.getErrMsg();
     }
     
     /**
@@ -246,5 +261,39 @@ public class McpServingManifestStorage {
     private static NacosException storageFailure(String message, Throwable cause) {
         return cause == null ? new NacosException(NacosException.SERVER_ERROR, message)
             : new NacosException(NacosException.SERVER_ERROR, message, cause);
+    }
+    
+    /**
+     * Migration-only Manifest page with row-level diagnostics.
+     *
+     * @author Nacos
+     */
+    public static final class ReconciliationPage extends Page<McpServerVersionInfo> {
+        
+        private static final long serialVersionUID = 3391973742548073578L;
+        
+        private final List<String> failures = new ArrayList<>();
+        
+        /**
+         * Create a migration scan page with existing diagnostics.
+         *
+         * @param failures non-null existing row-level scan failures
+         */
+        public ReconciliationPage(List<String> failures) {
+            this.failures.addAll(failures);
+        }
+        
+        /**
+         * Return immutable row-level scan failures.
+         *
+         * @return row-level scan failures
+         */
+        public List<String> getFailures() {
+            return Collections.unmodifiableList(failures);
+        }
+        
+        private void addFailure(String failure) {
+            failures.add(failure);
+        }
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorage.java
@@ -25,15 +25,22 @@ import com.alibaba.nacos.api.config.ConfigType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
 import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
 import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.ConfigDetailService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Owns Config access for the historical MCP serving Manifest.
@@ -50,12 +57,16 @@ public class McpServingManifestStorage {
     
     private final ConfigOperationService configOperationService;
     
+    private final ConfigDetailService configDetailService;
+    
     private final SyncEffectService syncEffectService;
     
     public McpServingManifestStorage(ConfigQueryChainService configQueryChainService,
-        ConfigOperationService configOperationService, SyncEffectService syncEffectService) {
+        ConfigOperationService configOperationService, ConfigDetailService configDetailService,
+        SyncEffectService syncEffectService) {
         this.configQueryChainService = configQueryChainService;
         this.configOperationService = configOperationService;
+        this.configDetailService = configDetailService;
         this.syncEffectService = syncEffectService;
     }
     
@@ -98,6 +109,47 @@ public class McpServingManifestStorage {
             throw storageFailure("MCP serving Manifest id does not match its Config coordinate",
                 null);
         }
+        return result;
+    }
+    
+    /**
+     * Page historical serving Manifests in one Namespace.
+     *
+     * <p>The scan remains encapsulated by Manifest Storage so lifecycle reconciliation never
+     * depends on the process-local MCP index or calls Config persistence directly.</p>
+     *
+     * @param namespaceId namespace identifier
+     * @param pageNo one-based page number
+     * @param pageSize positive page size
+     * @return decoded and coordinate-validated Manifests
+     * @throws NacosException when Config paging or decoding fails
+     */
+    public Page<McpServerVersionInfo> list(String namespaceId, int pageNo, int pageSize)
+        throws NacosException {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        if (pageNo <= 0 || pageSize <= 0) {
+            throw new IllegalArgumentException("MCP serving Manifest page must be positive");
+        }
+        final Page<ConfigInfo> configPage;
+        try {
+            configPage = configDetailService.findConfigInfoPage(Constants.MCP_LIST_SEARCH_BLUR,
+                pageNo, pageSize, Constants.ALL_PATTERN, Constants.MCP_SERVER_VERSIONS_GROUP,
+                namespaceId, Collections.emptyMap());
+        } catch (RuntimeException e) {
+            throw storageFailure("MCP serving Manifest page cannot be read", e);
+        }
+        if (configPage == null || configPage.getPageItems() == null) {
+            throw storageFailure("MCP serving Manifest query returned no page", null);
+        }
+        List<McpServerVersionInfo> manifests = new ArrayList<>(configPage.getPageItems().size());
+        for (ConfigInfo configInfo : configPage.getPageItems()) {
+            manifests.add(decodeListedManifest(namespaceId, configInfo));
+        }
+        Page<McpServerVersionInfo> result = new Page<>();
+        result.setPageNumber(pageNo);
+        result.setPagesAvailable(configPage.getPagesAvailable());
+        result.setTotalCount(configPage.getTotalCount());
+        result.setPageItems(manifests);
         return result;
     }
     
@@ -152,6 +204,28 @@ public class McpServingManifestStorage {
         result.setSrcUser("nacos");
         result.setConfigTags(McpConfigUtils.buildMcpServerVersionConfigTags(manifest.getName()));
         return result;
+    }
+    
+    private McpServerVersionInfo decodeListedManifest(String namespaceId, ConfigInfo configInfo)
+        throws NacosException {
+        if (configInfo == null) {
+            throw storageFailure("MCP serving Manifest page contains an empty row", null);
+        }
+        final McpServerVersionInfo manifest;
+        try {
+            manifest = JacksonUtils.toObj(configInfo.getContent(), McpServerVersionInfo.class);
+            validateManifest(manifest);
+        } catch (NacosDeserializationException | IllegalArgumentException e) {
+            throw storageFailure("MCP serving Manifest page contains invalid content", e);
+        }
+        String expectedDataId = McpConfigUtils.formatServerVersionInfoDataId(manifest.getId());
+        if (!expectedDataId.equals(configInfo.getDataId())
+            || !Constants.MCP_SERVER_VERSIONS_GROUP.equals(configInfo.getGroup())) {
+            throw storageFailure(
+                "MCP serving Manifest identity does not match its Config coordinate", null);
+        }
+        manifest.setNamespaceId(namespaceId);
+        return manifest;
     }
     
     private void validateCoordinate(String namespaceId, String mcpId) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.AiResourceConstants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.service.mcp.McpHistoricalResourceReconciler;
 import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage;
+import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage.ReconciliationPage;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
@@ -115,7 +116,8 @@ class McpLifecycleReconciliationTaskTest {
             .thenReturn(notFoundResponse());
         lenient().when(namespaceOperationService.getNamespaceList())
             .thenReturn(Collections.singletonList(new Namespace(PUBLIC_NAMESPACE, "public")));
-        lenient().when(manifestStorage.list(any(), anyInt(), eq(100))).thenReturn(emptyPage());
+        lenient().when(manifestStorage.list(any(), anyInt(), eq(100)))
+            .thenReturn(emptyManifestPage());
         lenient().when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
             .thenReturn(emptyPage());
     }
@@ -135,7 +137,7 @@ class McpLifecycleReconciliationTaskTest {
     void testExecutePersistsChangedSyncingProgressAndReleasesLease() throws Exception {
         McpServerVersionInfo manifest = manifest("demo", MCP_ID);
         when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
-            .thenReturn(page(Collections.singletonList(manifest), 1, 1));
+            .thenReturn(manifestPage(Collections.singletonList(manifest), 1, 1));
         when(reconciler.reconcile(PUBLIC_NAMESPACE, manifest)).thenReturn(2);
         
         task.executeReconciliation();
@@ -187,10 +189,10 @@ class McpLifecycleReconciliationTaskTest {
         McpServerVersionInfo duplicate = manifest("demo",
             "11111111-1111-1111-1111-111111111111");
         when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
-            .thenReturn(page(Collections.singletonList(first), 101, 0));
+            .thenReturn(manifestPage(Collections.singletonList(first), 101, 0));
         when(manifestStorage.list(PUBLIC_NAMESPACE, 2, 100))
-            .thenReturn(page(Collections.singletonList(duplicate), 101, 0));
-        when(manifestStorage.list(TEAM_NAMESPACE, 1, 100)).thenReturn(emptyPage());
+            .thenReturn(manifestPage(Collections.singletonList(duplicate), 101, 0));
+        when(manifestStorage.list(TEAM_NAMESPACE, 1, 100)).thenReturn(emptyManifestPage());
         
         task.executeReconciliation();
         
@@ -213,7 +215,7 @@ class McpLifecycleReconciliationTaskTest {
         McpServerVersionInfo second = manifest("second",
             "11111111-1111-1111-1111-111111111111");
         when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
-            .thenReturn(page(Arrays.asList(first, second), 2, 1));
+            .thenReturn(manifestPage(Arrays.asList(first, second), 2, 1));
         when(reconciler.reconcile(PUBLIC_NAMESPACE, first))
             .thenThrow(new IllegalStateException("conflict"));
         when(reconciler.reconcile(PUBLIC_NAMESPACE, second)).thenReturn(1);
@@ -225,6 +227,37 @@ class McpLifecycleReconciliationTaskTest {
         assertEquals(1, progress.get("failed"));
         assertEquals(1, progress.get("changed"));
         assertTrue(String.valueOf(progress.get("lastError")).contains("first"));
+    }
+    
+    @Test
+    void testExecuteContinuesAfterInvalidManifestRowsAndSkipsUnsafeOrphanScan()
+        throws Exception {
+        when(namespaceOperationService.getNamespaceList()).thenReturn(Arrays.asList(
+            new Namespace(TEAM_NAMESPACE, "team"),
+            new Namespace(PUBLIC_NAMESPACE, "public")));
+        McpServerVersionInfo publicManifest = manifest("public-demo", MCP_ID);
+        McpServerVersionInfo teamManifest = manifest("team-demo",
+            "11111111-1111-1111-1111-111111111111");
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100)).thenReturn(manifestPage(
+            Collections.singletonList(publicManifest), 2, 1,
+            "Invalid historical MCP serving Manifest public/broken"));
+        when(manifestStorage.list(TEAM_NAMESPACE, 1, 100)).thenReturn(manifestPage(
+            Collections.singletonList(teamManifest), 1, 1));
+        
+        task.executeReconciliation();
+        
+        verify(reconciler).reconcile(PUBLIC_NAMESPACE, publicManifest);
+        verify(reconciler).reconcile(TEAM_NAMESPACE, teamManifest);
+        ArgumentCaptor<QueryCondition> conditionCaptor =
+            ArgumentCaptor.forClass(QueryCondition.class);
+        verify(resourcePersistService).list(conditionCaptor.capture(), eq(1), eq(100));
+        assertEquals(TEAM_NAMESPACE, conditionCaptor.getValue().getNamespaceId());
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(2, progress.get("namespaces"));
+        assertEquals(2, progress.get("manifests"));
+        assertEquals(1, progress.get("failed"));
+        assertEquals(false, progress.get("zeroDifference"));
+        assertTrue(String.valueOf(progress.get("lastError")).contains("public/broken"));
     }
     
     @Test
@@ -554,6 +587,19 @@ class McpLifecycleReconciliationTaskTest {
     
     private <T> Page<T> emptyPage() {
         return page(Collections.emptyList(), 0, 0);
+    }
+    
+    private ReconciliationPage emptyManifestPage() {
+        return manifestPage(Collections.emptyList(), 0, 0);
+    }
+    
+    private ReconciliationPage manifestPage(List<McpServerVersionInfo> items, int totalCount,
+        int pagesAvailable, String... failures) {
+        ReconciliationPage result = new ReconciliationPage(Arrays.asList(failures));
+        result.setPageItems(items);
+        result.setTotalCount(totalCount);
+        result.setPagesAvailable(pagesAvailable);
+        return result;
     }
     
     private <T> Page<T> page(List<T> items, int totalCount, int pagesAvailable) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -210,6 +211,22 @@ class McpLifecycleReconciliationTaskTest {
     }
     
     @Test
+    void testExecuteDetectsDuplicateManifestIdAcrossDifferentNames() throws Exception {
+        McpServerVersionInfo first = manifest("first", MCP_ID);
+        McpServerVersionInfo duplicate = manifest("second", MCP_ID);
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenReturn(manifestPage(Arrays.asList(first, duplicate), 2, 1));
+        
+        task.executeReconciliation();
+        
+        verify(reconciler).reconcile(PUBLIC_NAMESPACE, first);
+        verify(reconciler, never()).reconcile(PUBLIC_NAMESPACE, duplicate);
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(2, progress.get("manifests"));
+        assertEquals(1, progress.get("failed"));
+    }
+    
+    @Test
     void testExecuteContinuesAfterResourceFailureAndPersistsLastError() throws Exception {
         McpServerVersionInfo first = manifest("first", MCP_ID);
         McpServerVersionInfo second = manifest("second",
@@ -298,6 +315,32 @@ class McpLifecycleReconciliationTaskTest {
     }
     
     @Test
+    void testExecuteRejectsOtherInvalidResourceRowsAndAcceptsNonLegacyRows() throws Exception {
+        AiResource wrongType = legacyResource("wrong-type");
+        wrongType.setType(AiResourceConstants.RESOURCE_TYPE_SKILL);
+        AiResource blankName = legacyResource(" ");
+        AiResource nonLegacy = legacyResource("local");
+        nonLegacy.setFrom("local");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(100)))
+            .thenReturn(page(Collections.singletonList(null), 1, 1),
+                page(Collections.singletonList(wrongType), 1, 1),
+                page(Collections.singletonList(blankName), 1, 1),
+                page(Collections.singletonList(nonLegacy), 1, 1));
+        
+        task.executeReconciliation();
+        task.executeReconciliation();
+        task.executeReconciliation();
+        task.executeReconciliation();
+        
+        verify(resourcePersistService, org.mockito.Mockito.times(4))
+            .list(any(QueryCondition.class), eq(1), eq(100));
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(0, progress.get("failed"));
+        assertEquals(0, progress.get("orphaned"));
+        assertEquals(true, progress.get("zeroDifference"));
+    }
+    
+    @Test
     void testExecuteRejectsNullManifestPage() throws Exception {
         when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100)).thenReturn(null);
         
@@ -320,6 +363,20 @@ class McpLifecycleReconciliationTaskTest {
         assertEquals(false, progress.get("completeNamespaceScan"));
         assertEquals(false, progress.get("zeroDifference"));
         assertTrue(((Number) progress.get("failed")).intValue() > 0);
+    }
+    
+    @Test
+    void testExecuteFallsBackForNullEmptyAndBlankNamespaceLists() throws Exception {
+        when(namespaceOperationService.getNamespaceList()).thenReturn(null,
+            Collections.emptyList(),
+            Arrays.asList(null, new Namespace(" ", "blank")));
+        
+        task.executeReconciliation();
+        task.executeReconciliation();
+        task.executeReconciliation();
+        
+        verify(manifestStorage, org.mockito.Mockito.times(3))
+            .list(PUBLIC_NAMESPACE, 1, 100);
     }
     
     @Test
@@ -425,6 +482,17 @@ class McpLifecycleReconciliationTaskTest {
             .publishConfig(any(), any(), isNull());
         task.executeReconciliation();
         verifyNoInteractions(manifestStorage, reconciler);
+    }
+    
+    @Test
+    void testReadLeaseTreatsNullAndBlankResponsesAsAbsent() {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(null);
+        assertNull(ReflectionTestUtils.invokeMethod(task, "readLease"));
+        
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse(" ", "md5"));
+        assertNull(ReflectionTestUtils.invokeMethod(task, "readLease"));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/McpLifecycleReconciliationTaskTest.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.service.mcp.McpHistoricalResourceReconciler;
+import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.response.Namespace;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.core.service.NamespaceOperationService;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpLifecycleReconciliationTaskTest {
+    
+    private static final String PUBLIC_NAMESPACE = "public";
+    
+    private static final String TEAM_NAMESPACE = "team-a";
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    private static final ConfigurableEnvironment CACHED_ENVIRONMENT = EnvUtil.getEnvironment();
+    
+    @Mock
+    private NamespaceOperationService namespaceOperationService;
+    
+    @Mock
+    private McpServingManifestStorage manifestStorage;
+    
+    @Mock
+    private McpHistoricalResourceReconciler reconciler;
+    
+    @Mock
+    private AiResourcePersistService resourcePersistService;
+    
+    @Mock
+    private ConfigQueryChainService configQueryChainService;
+    
+    @Mock
+    private ConfigOperationService configOperationService;
+    
+    private McpLifecycleReconciliationTask task;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        task = new McpLifecycleReconciliationTask(namespaceOperationService, manifestStorage,
+            reconciler, resourcePersistService, configQueryChainService,
+            configOperationService);
+        lenient().when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(notFoundResponse());
+        lenient().when(namespaceOperationService.getNamespaceList())
+            .thenReturn(Collections.singletonList(new Namespace(PUBLIC_NAMESPACE, "public")));
+        lenient().when(manifestStorage.list(any(), anyInt(), eq(100))).thenReturn(emptyPage());
+        lenient().when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(emptyPage());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        if (task != null) {
+            task.destroy();
+        }
+        System.clearProperty(McpLifecycleReconciliationTask.RECONCILIATION_ENABLED_KEY);
+        System.clearProperty(
+            McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY);
+        EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
+    }
+    
+    @Test
+    void testExecutePersistsChangedSyncingProgressAndReleasesLease() throws Exception {
+        McpServerVersionInfo manifest = manifest("demo", MCP_ID);
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenReturn(page(Collections.singletonList(manifest), 1, 1));
+        when(reconciler.reconcile(PUBLIC_NAMESPACE, manifest)).thenReturn(2);
+        
+        task.executeReconciliation();
+        
+        verify(reconciler).reconcile(PUBLIC_NAMESPACE, manifest);
+        List<ConfigForm> forms = capturedForms();
+        assertEquals(3, forms.size());
+        assertEquals(McpLifecycleReconciliationTask.RECONCILIATION_LEASE_DATA_ID,
+            forms.get(0).getDataId());
+        assertEquals(McpLifecycleReconciliationTask.RECONCILIATION_PROGRESS_DATA_ID,
+            forms.get(1).getDataId());
+        assertEquals(McpLifecycleReconciliationTask.RECONCILIATION_LEASE_DATA_ID,
+            forms.get(2).getDataId());
+        assertTrue(forms.get(2).getContent().endsWith("|0"));
+        Map<?, ?> progress = JacksonUtils.toObj(forms.get(1).getContent(), Map.class);
+        assertEquals("SYNCING", progress.get("state"));
+        assertEquals(1, progress.get("manifests"));
+        assertEquals(2, progress.get("changed"));
+        assertEquals(false, progress.get("zeroDifference"));
+        assertEquals(true, progress.get("searchBackfillPending"));
+        assertEquals(false, progress.get("managedCutoverReady"));
+        assertFalse(forms.stream()
+            .anyMatch(form -> "nacos.ai.mcp.resource.migration.v1".equals(form.getDataId())));
+        ArgumentCaptor<ConfigRequestInfo> requestCaptor =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService, org.mockito.Mockito.times(3)).publishConfig(any(),
+            requestCaptor.capture(), isNull());
+        assertTrue(requestCaptor.getAllValues().get(1).getUpdateForExist());
+    }
+    
+    @Test
+    void testExecuteRecordsZeroDifferenceForCompleteEmptyScan() throws Exception {
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("namespaces"));
+        assertEquals(0, progress.get("failed"));
+        assertEquals(true, progress.get("completeNamespaceScan"));
+        assertEquals(true, progress.get("zeroDifference"));
+    }
+    
+    @Test
+    void testExecutePagesSortedNamespacesAndDetectsDuplicateIdentity() throws Exception {
+        when(namespaceOperationService.getNamespaceList()).thenReturn(Arrays.asList(
+            new Namespace(TEAM_NAMESPACE, "team"), null,
+            new Namespace(PUBLIC_NAMESPACE, "public"),
+            new Namespace(PUBLIC_NAMESPACE, "duplicate")));
+        McpServerVersionInfo first = manifest("demo", MCP_ID);
+        McpServerVersionInfo duplicate = manifest("demo",
+            "11111111-1111-1111-1111-111111111111");
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenReturn(page(Collections.singletonList(first), 101, 0));
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 2, 100))
+            .thenReturn(page(Collections.singletonList(duplicate), 101, 0));
+        when(manifestStorage.list(TEAM_NAMESPACE, 1, 100)).thenReturn(emptyPage());
+        
+        task.executeReconciliation();
+        
+        InOrder order = inOrder(manifestStorage);
+        order.verify(manifestStorage).list(PUBLIC_NAMESPACE, 1, 100);
+        order.verify(manifestStorage).list(PUBLIC_NAMESPACE, 2, 100);
+        order.verify(manifestStorage).list(TEAM_NAMESPACE, 1, 100);
+        verify(reconciler).reconcile(PUBLIC_NAMESPACE, first);
+        verify(reconciler, never()).reconcile(PUBLIC_NAMESPACE, duplicate);
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(2, progress.get("namespaces"));
+        assertEquals(2, progress.get("manifests"));
+        assertEquals(1, progress.get("failed"));
+        assertEquals(false, progress.get("zeroDifference"));
+    }
+    
+    @Test
+    void testExecuteContinuesAfterResourceFailureAndPersistsLastError() throws Exception {
+        McpServerVersionInfo first = manifest("first", MCP_ID);
+        McpServerVersionInfo second = manifest("second",
+            "11111111-1111-1111-1111-111111111111");
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenReturn(page(Arrays.asList(first, second), 2, 1));
+        when(reconciler.reconcile(PUBLIC_NAMESPACE, first))
+            .thenThrow(new IllegalStateException("conflict"));
+        when(reconciler.reconcile(PUBLIC_NAMESPACE, second)).thenReturn(1);
+        
+        task.executeReconciliation();
+        
+        verify(reconciler).reconcile(PUBLIC_NAMESPACE, second);
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("failed"));
+        assertEquals(1, progress.get("changed"));
+        assertTrue(String.valueOf(progress.get("lastError")).contains("first"));
+    }
+    
+    @Test
+    void testExecuteDetectsOrphanWithoutDeletingIt() throws Exception {
+        AiResource orphan = legacyResource("orphan");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(100)))
+            .thenReturn(page(Collections.singletonList(orphan), 101, 0));
+        when(resourcePersistService.list(any(QueryCondition.class), eq(2), eq(100)))
+            .thenReturn(emptyPage());
+        
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("orphaned"));
+        assertEquals(1, progress.get("failed"));
+        assertTrue(String.valueOf(progress.get("lastError")).contains("orphan"));
+        verify(resourcePersistService, never()).delete(any(), any(), any());
+        verifyNoInteractions(reconciler);
+    }
+    
+    @Test
+    void testExecuteRejectsInconsistentResourcePage() throws Exception {
+        AiResource inconsistent = legacyResource("bad");
+        inconsistent.setNamespaceId(TEAM_NAMESPACE);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(100)))
+            .thenReturn(page(Collections.singletonList(inconsistent), 1, 1));
+        
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("failed"));
+        assertTrue(String.valueOf(progress.get("lastError")).contains("inconsistent"));
+        
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(100)))
+            .thenReturn(null);
+        task.executeReconciliation();
+        assertTrue(String.valueOf(capturedProgress().get("lastError")).contains("Unable to page"));
+    }
+    
+    @Test
+    void testExecuteRejectsNullManifestPage() throws Exception {
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100)).thenReturn(null);
+        
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("failed"));
+        assertTrue(String.valueOf(progress.get("lastError")).contains("empty page"));
+    }
+    
+    @Test
+    void testExecuteFallsBackToPublicAndKeepsScanIncomplete() throws Exception {
+        when(namespaceOperationService.getNamespaceList())
+            .thenThrow(new IllegalStateException("namespace unavailable"));
+        
+        task.executeReconciliation();
+        
+        verify(manifestStorage).list(PUBLIC_NAMESPACE, 1, 100);
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(false, progress.get("completeNamespaceScan"));
+        assertEquals(false, progress.get("zeroDifference"));
+        assertTrue(((Number) progress.get("failed")).intValue() > 0);
+    }
+    
+    @Test
+    void testExecutePersistsUnexpectedScanFailureAndTruncatesError() throws Exception {
+        String longError = "x".repeat(3000);
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenThrow(new IllegalStateException(longError));
+        
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(2048, String.valueOf(progress.get("lastError")).length());
+        assertEquals(1, progress.get("failed"));
+    }
+    
+    @Test
+    void testExecuteRecordsFailureWithoutMessage() throws Exception {
+        when(manifestStorage.list(PUBLIC_NAMESPACE, 1, 100))
+            .thenThrow(new IllegalStateException());
+        
+        task.executeReconciliation();
+        
+        Map<?, ?> progress = capturedProgress();
+        assertEquals(1, progress.get("failed"));
+        assertFalse(progress.containsKey("lastError"));
+    }
+    
+    @Test
+    void testActiveOrUnverifiableLeaseSkipsReconciliation() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(
+            foundResponse("owner|" + (System.currentTimeMillis() + 60000), "md5"));
+        task.executeReconciliation();
+        verifyNoInteractions(manifestStorage, reconciler);
+        verify(configOperationService, never()).publishConfig(any(), any(), any());
+        
+        reset(configQueryChainService, configOperationService, manifestStorage, reconciler);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("owner|0", null));
+        task.executeReconciliation();
+        verify(configOperationService, never()).publishConfig(any(), any(), any());
+    }
+    
+    @Test
+    void testExpiredLeaseUsesCasAndCompletesScan() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("owner|0", "old-md5"));
+        
+        task.executeReconciliation();
+        
+        ArgumentCaptor<ConfigRequestInfo> requestCaptor =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService, org.mockito.Mockito.atLeastOnce()).publishConfig(any(),
+            requestCaptor.capture(), isNull());
+        ConfigRequestInfo acquire = requestCaptor.getAllValues().get(0);
+        assertEquals("old-md5", acquire.getCasMd5());
+        assertEquals(true, acquire.getUpdateForExist());
+        assertNotNull(capturedProgress());
+    }
+    
+    @Test
+    void testLeaseCreateRacesAndFailuresSkipWork() throws Exception {
+        doThrow(new ConfigAlreadyExistsException("race")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        task.executeReconciliation();
+        verifyNoInteractions(manifestStorage, reconciler);
+        
+        reset(configOperationService, manifestStorage, reconciler);
+        doThrow(new IllegalStateException("failed")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        task.executeReconciliation();
+        verifyNoInteractions(manifestStorage, reconciler);
+    }
+    
+    @Test
+    void testExpiredLeaseTakeoverFailureSkipsWork() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("owner|0", "old-md5"));
+        doThrow(new IllegalStateException("takeover lost")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        
+        task.executeReconciliation();
+        
+        verifyNoInteractions(manifestStorage, reconciler);
+    }
+    
+    @Test
+    void testMalformedOrConflictingLeaseNeverOverwritesExistingConfig() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(foundResponse("malformed", "md5"));
+        doThrow(new ConfigAlreadyExistsException("exists")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        task.executeReconciliation();
+        verifyNoInteractions(manifestStorage, reconciler);
+        
+        reset(configQueryChainService, configOperationService, manifestStorage, reconciler);
+        ConfigQueryChainResponse conflict = new ConfigQueryChainResponse();
+        conflict.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_QUERY_CONFLICT);
+        conflict.setMessage("conflict");
+        conflict.setContent("owner|0");
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(conflict);
+        doThrow(new ConfigAlreadyExistsException("exists")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        task.executeReconciliation();
+        verifyNoInteractions(manifestStorage, reconciler);
+    }
+    
+    @Test
+    void testLeaseRenewalSuccessFailureAndReleaseFailureAreContained() throws Exception {
+        Object lease = ReflectionTestUtils.invokeMethod(task, "tryAcquireLease");
+        assertNotNull(lease);
+        ReflectionTestUtils.invokeMethod(lease, "renewSafely");
+        assertEquals(true, ReflectionTestUtils.invokeMethod(lease, "isOwned"));
+        ReflectionTestUtils.invokeMethod(lease, "close");
+        
+        reset(configOperationService);
+        lease = ReflectionTestUtils.invokeMethod(task, "tryAcquireLease");
+        assertNotNull(lease);
+        doThrow(new IllegalStateException("renew failed")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        ReflectionTestUtils.invokeMethod(lease, "renewSafely");
+        assertEquals(false, ReflectionTestUtils.invokeMethod(lease, "isOwned"));
+        ReflectionTestUtils.invokeMethod(lease, "renewSafely");
+        Object lostLease = lease;
+        assertThrows(IllegalStateException.class,
+            () -> ReflectionTestUtils.invokeMethod(lostLease, "assertOwned"));
+        ReflectionTestUtils.invokeMethod(lease, "close");
+        
+        reset(configOperationService);
+        lease = ReflectionTestUtils.invokeMethod(task, "tryAcquireLease");
+        assertNotNull(lease);
+        doThrow(new IllegalStateException("release failed")).when(configOperationService)
+            .publishConfig(any(), any(), isNull());
+        ReflectionTestUtils.invokeMethod(lease, "close");
+    }
+    
+    @Test
+    void testProgressFailureDoesNotPreventLeaseRelease() throws Exception {
+        when(configOperationService.publishConfig(any(), any(), isNull())).thenReturn(true)
+            .thenThrow(new IllegalStateException("progress failed")).thenReturn(true);
+        
+        task.executeReconciliation();
+        
+        ArgumentCaptor<ConfigForm> captor = ArgumentCaptor.forClass(ConfigForm.class);
+        verify(configOperationService, org.mockito.Mockito.times(3))
+            .publishConfig(captor.capture(), any(), isNull());
+        assertTrue(captor.getAllValues().get(2).getContent().endsWith("|0"));
+    }
+    
+    @Test
+    void testApplicationReadyHonorsRootDisabledAndSingleInitialization() throws Exception {
+        task.onApplicationEvent(childContextEvent());
+        verifyNoInteractions(configOperationService);
+        
+        System.setProperty(McpLifecycleReconciliationTask.RECONCILIATION_ENABLED_KEY, "false");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        task.onApplicationEvent(rootContextEvent());
+        task.onApplicationEvent(rootContextEvent());
+        verify(configOperationService, after(300).never()).publishConfig(any(), any(), any());
+    }
+    
+    @Test
+    void testApplicationReadySchedulesEnabledReconciliation() throws Exception {
+        System.setProperty(McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY,
+            "1");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        
+        task.onApplicationEvent(rootContextEvent());
+        
+        verify(configOperationService, timeout(2000).atLeastOnce())
+            .publishConfig(any(), any(), isNull());
+    }
+    
+    @Test
+    void testPositiveLongUsesConfiguredAndFallbackValues() {
+        System.setProperty(McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY,
+            "7");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        assertEquals(7L, invokePositiveLong());
+        
+        System.setProperty(McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY,
+            "0");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        assertEquals(3L, invokePositiveLong());
+        
+        System.setProperty(McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY,
+            "invalid");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        assertEquals(3L, invokePositiveLong());
+    }
+    
+    private long invokePositiveLong() {
+        Number result = ReflectionTestUtils.invokeMethod(task, "positiveLong",
+            McpLifecycleReconciliationTask.RECONCILIATION_INTERVAL_SECONDS_KEY, 3L);
+        return result.longValue();
+    }
+    
+    private List<ConfigForm> capturedForms() throws Exception {
+        ArgumentCaptor<ConfigForm> captor = ArgumentCaptor.forClass(ConfigForm.class);
+        verify(configOperationService, org.mockito.Mockito.atLeastOnce())
+            .publishConfig(captor.capture(), any(), isNull());
+        return captor.getAllValues();
+    }
+    
+    private Map<?, ?> capturedProgress() throws Exception {
+        List<ConfigForm> progressForms = capturedForms().stream()
+            .filter(form -> McpLifecycleReconciliationTask.RECONCILIATION_PROGRESS_DATA_ID
+                .equals(form.getDataId()))
+            .toList();
+        if (progressForms.isEmpty()) {
+            return null;
+        }
+        return JacksonUtils.toObj(progressForms.get(progressForms.size() - 1).getContent(),
+            Map.class);
+    }
+    
+    private ApplicationReadyEvent rootContextEvent() {
+        ApplicationReadyEvent event = org.mockito.Mockito.mock(ApplicationReadyEvent.class);
+        ConfigurableApplicationContext context =
+            org.mockito.Mockito.mock(ConfigurableApplicationContext.class);
+        when(event.getApplicationContext()).thenReturn(context);
+        when(context.getParent()).thenReturn(null);
+        return event;
+    }
+    
+    private ApplicationReadyEvent childContextEvent() {
+        ApplicationReadyEvent event = org.mockito.Mockito.mock(ApplicationReadyEvent.class);
+        ConfigurableApplicationContext context =
+            org.mockito.Mockito.mock(ConfigurableApplicationContext.class);
+        when(event.getApplicationContext()).thenReturn(context);
+        when(context.getParent()).thenReturn(
+            org.mockito.Mockito.mock(org.springframework.context.ApplicationContext.class));
+        return event;
+    }
+    
+    private McpServerVersionInfo manifest(String name, String id) {
+        McpServerVersionInfo result = new McpServerVersionInfo();
+        result.setName(name);
+        result.setId(id);
+        return result;
+    }
+    
+    private AiResource legacyResource(String name) {
+        AiResource result = new AiResource();
+        result.setNamespaceId(PUBLIC_NAMESPACE);
+        result.setName(name);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        result.setFrom(McpHistoricalResourceReconciler.LEGACY_SOURCE);
+        return result;
+    }
+    
+    private ConfigQueryChainResponse notFoundResponse() {
+        ConfigQueryChainResponse result = new ConfigQueryChainResponse();
+        result.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND);
+        return result;
+    }
+    
+    private ConfigQueryChainResponse foundResponse(String content, String md5) {
+        ConfigQueryChainResponse result = new ConfigQueryChainResponse();
+        result.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        result.setContent(content);
+        result.setMd5(md5);
+        return result;
+    }
+    
+    private <T> Page<T> emptyPage() {
+        return page(Collections.emptyList(), 0, 0);
+    }
+    
+    private <T> Page<T> page(List<T> items, int totalCount, int pagesAvailable) {
+        Page<T> result = new Page<>();
+        result.setPageItems(items);
+        result.setTotalCount(totalCount);
+        result.setPagesAvailable(pagesAvailable);
+        return result;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconcilerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconcilerTest.java
@@ -1,0 +1,691 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp;
+
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.ai.model.mcp.McpServerStorageInfo;
+import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.ai.service.mcp.storage.McpResourceExtSerializer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageContents;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageDescriptorSerializer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageKeyComposer;
+import com.alibaba.nacos.ai.service.mcp.storage.McpVersionStorageService;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpHistoricalResourceReconcilerTest {
+    
+    private static final String NAMESPACE_ID = "public";
+    
+    private static final String MCP_ID = "4d7939c0-72ea-4ef4-b232-418d1e16b45c";
+    
+    private static final String MCP_NAME = "demo";
+    
+    private static final String VERSION = "1.0.0";
+    
+    @Mock
+    private McpVersionStorageService versionStorageService;
+    
+    @Mock
+    private AiResourcePersistService resourcePersistService;
+    
+    @Mock
+    private AiResourceVersionPersistService versionPersistService;
+    
+    private McpHistoricalResourceReconciler reconciler;
+    
+    @BeforeEach
+    void setUp() {
+        reconciler = new McpHistoricalResourceReconciler(versionStorageService,
+            resourcePersistService, versionPersistService);
+    }
+    
+    @Test
+    void testReconcileCreatesVersionsBeforeResourceWithoutRewritingPayload() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION, "2.0.0");
+        stubStorage(VERSION, "2.0.0");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(1L);
+        when(resourcePersistService.insert(any(AiResource.class))).thenReturn(1L);
+        
+        assertEquals(3, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        ArgumentCaptor<AiResourceVersion> versionCaptor =
+            ArgumentCaptor.forClass(AiResourceVersion.class);
+        verify(versionPersistService, org.mockito.Mockito.times(2))
+            .insert(versionCaptor.capture());
+        assertEquals(Arrays.asList(VERSION, "2.0.0"),
+            versionCaptor.getAllValues().stream().map(AiResourceVersion::getVersion).toList());
+        for (AiResourceVersion row : versionCaptor.getAllValues()) {
+            assertEquals(AiResourceConstants.VERSION_STATUS_ONLINE, row.getStatus());
+            assertEquals("nacos", row.getAuthor());
+            assertEquals("", row.getDesc());
+            McpVersionStorageDescriptor descriptor =
+                McpVersionStorageDescriptorSerializer.deserialize(row.getStorage());
+            assertTrue(descriptor.getServerKey().contains(MCP_ID));
+            assertNotNull(descriptor.getToolKey());
+            assertNotNull(descriptor.getResourceKey());
+        }
+        ArgumentCaptor<AiResource> resourceCaptor = ArgumentCaptor.forClass(AiResource.class);
+        verify(resourcePersistService).insert(resourceCaptor.capture());
+        assertResource(resourceCaptor.getValue(), manifest, 2);
+        verify(versionStorageService, never()).save(any(), any());
+        verify(versionStorageService, never()).delete(any());
+    }
+    
+    @Test
+    void testReconcileIsZeroDifferenceForEquivalentRowsAndSemanticJson() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource resource = expectedResource(manifest, 1);
+        resource.setBizTags(" [ ] ");
+        ResourceVersionInfo versionInfo = JacksonUtils.toObj(resource.getVersionInfo(),
+            ResourceVersionInfo.class);
+        resource.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        AiResourceVersion version = expectedVersion(VERSION);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(resource), 1, 1));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(version), 1, 1));
+        
+        assertEquals(0, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        verify(versionPersistService, never()).insert(any());
+        verify(resourcePersistService, never()).insert(any());
+        verify(resourcePersistService, never()).updateMetaCas(any(), any(), any(),
+            org.mockito.ArgumentMatchers.anyLong(), any());
+    }
+    
+    @Test
+    void testReconcileRepairsMutableLegacyMetadataWithCas() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        manifest.setEnabled(false);
+        stubStorage(VERSION);
+        AiResource stale = expectedResource(manifest, 1);
+        stale.setMetaVersion(7L);
+        stale.setDesc("stale");
+        stale.setStatus(AiResourceConstants.META_STATUS_ENABLE);
+        stale.setBizTags(null);
+        stale.setVersionInfo("not-json");
+        stubRows(stale, Collections.singletonList(expectedVersion(VERSION)));
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(MCP_NAME),
+            eq(AiResourceConstants.RESOURCE_TYPE_MCP), eq(7L), any(AiResource.class)))
+            .thenReturn(true);
+        
+        assertEquals(1, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        ArgumentCaptor<AiResource> captor = ArgumentCaptor.forClass(AiResource.class);
+        verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(MCP_NAME),
+            eq(AiResourceConstants.RESOURCE_TYPE_MCP), eq(7L), captor.capture());
+        assertEquals(AiResourceConstants.META_STATUS_DISABLE, captor.getValue().getStatus());
+        assertEquals("legacy description", captor.getValue().getDesc());
+    }
+    
+    @Test
+    void testReconcileRepairsMalformedMutableMetadata() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource stale = expectedResource(manifest, 1);
+        stale.setMetaVersion(7L);
+        stale.setBizTags("not-json");
+        stubRows(stale, Collections.singletonList(expectedVersion(VERSION)));
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(MCP_NAME),
+            eq(AiResourceConstants.RESOURCE_TYPE_MCP), eq(7L), any(AiResource.class)))
+            .thenReturn(true);
+        
+        assertEquals(1, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(resourcePersistService);
+        stale = expectedResource(manifest, 1);
+        stale.setMetaVersion(8L);
+        stale.setVersionInfo("not-json");
+        stubRows(stale, Collections.singletonList(expectedVersion(VERSION)));
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(MCP_NAME),
+            eq(AiResourceConstants.RESOURCE_TYPE_MCP), eq(8L), any(AiResource.class)))
+            .thenReturn(true);
+        
+        assertEquals(1, reconciler.reconcile(NAMESPACE_ID, manifest));
+    }
+    
+    @Test
+    void testReconcileRecoversConcurrentResourceCasAndInsert() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource expected = expectedResource(manifest, 1);
+        AiResource stale = expectedResource(manifest, 1);
+        stale.setMetaVersion(2L);
+        stale.setDesc("stale");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(stale), 1, 1),
+                page(Collections.singletonList(expected), 1, 1));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(expectedVersion(VERSION)), 1, 1));
+        when(resourcePersistService.updateMetaCas(any(), any(), any(), eq(2L), any()))
+            .thenReturn(false);
+        assertEquals(0, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(resourcePersistService);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0),
+                page(Collections.singletonList(expected), 1, 1));
+        when(resourcePersistService.insert(any(AiResource.class)))
+            .thenThrow(new IllegalStateException("race"));
+        assertEquals(0, reconciler.reconcile(NAMESPACE_ID, manifest));
+    }
+    
+    @Test
+    void testReconcileRejectsConcurrentResourceConflicts() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource stale = expectedResource(manifest, 1);
+        stale.setMetaVersion(2L);
+        stale.setDesc("stale");
+        AiResource conflicting = expectedResource(manifest, 1);
+        conflicting.setDesc("conflict");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(stale), 1, 1),
+                page(Collections.singletonList(conflicting), 1, 1));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(expectedVersion(VERSION)), 1, 1));
+        when(resourcePersistService.updateMetaCas(any(), any(), any(), eq(2L), any()))
+            .thenReturn(false);
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(resourcePersistService);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0),
+                page(Collections.singletonList(conflicting), 1, 1));
+        when(resourcePersistService.insert(any(AiResource.class)))
+            .thenThrow(new IllegalStateException("race"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(resourcePersistService);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0), page(Collections.emptyList(), 0, 0));
+        when(resourcePersistService.insert(any(AiResource.class)))
+            .thenThrow(new IllegalStateException("failed"));
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        reset(resourcePersistService);
+        AiResource duplicate = expectedResource(manifest, 1);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(stale), 1, 1),
+                page(Arrays.asList(conflicting, duplicate), 2, 1));
+        when(resourcePersistService.updateMetaCas(any(), any(), any(), eq(2L), any()))
+            .thenReturn(false);
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+    }
+    
+    @Test
+    void testReconcileRecoversConcurrentVersionInsertAndRejectsConflicts() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.insert(any(AiResourceVersion.class)))
+            .thenThrow(new IllegalStateException("race"));
+        when(versionPersistService.find(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, VERSION)).thenReturn(expectedVersion(VERSION));
+        when(resourcePersistService.insert(any(AiResource.class))).thenReturn(1L);
+        assertEquals(1, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionPersistService, resourcePersistService);
+        stubEmptyResource();
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.insert(any(AiResourceVersion.class)))
+            .thenThrow(new IllegalStateException("race"));
+        AiResourceVersion conflict = expectedVersion(VERSION);
+        conflict.setStatus(AiResourceConstants.VERSION_STATUS_DRAFT);
+        when(versionPersistService.find(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, VERSION)).thenReturn(conflict);
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        when(versionPersistService.find(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, VERSION)).thenReturn(null);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+    }
+    
+    @Test
+    void testReconcileRejectsDuplicateOrIndependentResourceRows() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource first = expectedResource(manifest, 1);
+        AiResource second = expectedResource(manifest, 1);
+        second.setFrom("local");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Arrays.asList(first, second), 2, 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        verifyNoInteractions(versionPersistService);
+        
+        reset(resourcePersistService);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Arrays.asList(first, second), 3, 2));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        verifyNoInteractions(versionPersistService);
+        
+        reset(resourcePersistService);
+        first.setFrom("local");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(first), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        verifyNoInteractions(versionPersistService);
+    }
+    
+    @Test
+    void testReconcileRejectsInvalidResourceQueryAndMetadataIdentity() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(null);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        AiResource inconsistent = expectedResource(manifest, 1);
+        inconsistent.setNamespaceId("other");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(inconsistent), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        AiResource badExt = expectedResource(manifest, 1);
+        badExt.setExt("{}");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(badExt), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        AiResource noMetaVersion = expectedResource(manifest, 1);
+        noMetaVersion.setMetaVersion(null);
+        noMetaVersion.setDesc("stale");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(noMetaVersion), 1, 1));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(expectedVersion(VERSION)), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+    }
+    
+    @Test
+    void testReconcileRejectsExtraOrConflictingVersionRows() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        AiResource resource = expectedResource(manifest, 1);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(resource), 1, 1));
+        AiResourceVersion expected = expectedVersion(VERSION);
+        AiResourceVersion extra = expectedVersion("0.9.0");
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Arrays.asList(expected, extra), 2, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        verify(versionPersistService, never()).delete(any(), any(), any(), any());
+        
+        expected.setStorage("{}");
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(expected), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        expected = expectedVersion(VERSION);
+        expected.setPublishPipelineInfo("{}");
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(expected), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+    }
+    
+    @Test
+    void testReconcilePagesVersionsAndRejectsInconsistentPages() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        stubEmptyResource();
+        Page<AiResourceVersion> firstPage = page(Collections.emptyList(), 101, 0);
+        Page<AiResourceVersion> secondPage = page(Collections.emptyList(), 101, 0);
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100)).thenReturn(firstPage);
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 2, 100)).thenReturn(secondPage);
+        when(versionPersistService.insert(any())).thenReturn(1L);
+        when(resourcePersistService.insert(any())).thenReturn(1L);
+        assertEquals(2, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionPersistService, resourcePersistService);
+        stubEmptyResource();
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100)).thenReturn(null);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        AiResourceVersion inconsistent = expectedVersion(VERSION);
+        inconsistent.setName("other");
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.singletonList(inconsistent), 1, 1));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+    }
+    
+    @Test
+    void testReconcileRejectsInvalidManifestShapesBeforeStorageAccess() {
+        assertInvalidManifest(null);
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile("invalid namespace", manifest(VERSION))).getErrCode());
+        
+        McpServerVersionInfo invalid = manifest(VERSION);
+        invalid.setName(" ");
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setName("x".repeat(257));
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setDescription("x".repeat(2049));
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setVersions(null);
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setVersions(Collections.emptyList());
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setVersions(Collections.singletonList(null));
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.getVersionDetails().get(0).setVersion(" ");
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.getVersionDetails().get(0).setVersion("x".repeat(65));
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION, VERSION);
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setLatestPublishedVersion("other");
+        assertInvalidManifest(invalid);
+        verifyNoInteractions(versionStorageService, resourcePersistService,
+            versionPersistService);
+    }
+    
+    @Test
+    void testReconcileValidatesServerToolsAndResourcesContent() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        when(versionStorageService.load(any())).thenReturn(
+            new McpVersionStorageContents(bytes("not-json"), null, null));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        when(versionStorageService.load(any())).thenReturn(
+            new McpVersionStorageContents(bytes("null"), null, null));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        McpServerStorageInfo wrongId = server(VERSION);
+        wrongId.setId("11111111-1111-1111-1111-111111111111");
+        stubContents(wrongId, wrongId, bytes("{}"), bytes("{}"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        McpServerStorageInfo conflictingVersion = server(VERSION);
+        conflictingVersion.setVersion("2.0.0");
+        stubContents(conflictingVersion, conflictingVersion, bytes("{}"), bytes("{}"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        McpServerStorageInfo changed = server(VERSION);
+        McpServerStorageInfo changedFull = server(VERSION);
+        changedFull.setDescription("changed");
+        stubContents(changed, changedFull, bytes("{}"), bytes("{}"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        stubContents(server(VERSION), server(VERSION), bytes("not-json"), bytes("{}"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        stubContents(server(VERSION), server(VERSION), bytes("{}"), bytes("not-json"));
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        reset(versionStorageService);
+        McpServerStorageInfo legacyVersion = server(VERSION);
+        legacyVersion.setVersionDetail(null);
+        legacyVersion.setVersion(VERSION);
+        stubContents(legacyVersion, legacyVersion, null, null);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(null);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+    }
+    
+    @Test
+    void testReconcilePropagatesMissingStorageContentWithoutDatabaseWrites() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        when(versionStorageService.load(any())).thenThrow(
+            new NacosException(NacosException.SERVER_ERROR, "missing"));
+        
+        assertThrows(NacosException.class, () -> reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        verifyNoInteractions(resourcePersistService, versionPersistService);
+    }
+    
+    private void assertInvalidManifest(McpServerVersionInfo manifest) {
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+    }
+    
+    private void stubRows(AiResource resource, List<AiResourceVersion> versions) {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(resource), 1, 1));
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(versions, versions.size(), 1));
+    }
+    
+    private void stubEmptyResource() {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+    }
+    
+    private void stubStorage(String... versions) throws Exception {
+        Map<String, McpServerStorageInfo> servers = new LinkedHashMap<>();
+        for (String version : versions) {
+            McpServerStorageInfo server = server(version);
+            McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.fromLegacy(
+                NAMESPACE_ID, MCP_ID, version, server);
+            servers.put(descriptor.getServerKey(), server);
+        }
+        when(versionStorageService.load(any())).thenAnswer(invocation -> {
+            McpVersionStorageDescriptor descriptor = invocation.getArgument(0);
+            McpServerStorageInfo server = servers.get(descriptor.getServerKey());
+            byte[] serverContent = bytes(JacksonUtils.toJson(server));
+            return descriptor.getToolKey() == null
+                ? new McpVersionStorageContents(serverContent, null, null)
+                : new McpVersionStorageContents(serverContent, bytes("{}"), bytes("{}"));
+        });
+    }
+    
+    private void stubContents(McpServerStorageInfo firstServer,
+        McpServerStorageInfo fullServer, byte[] tools, byte[] resources) throws Exception {
+        when(versionStorageService.load(any())).thenReturn(
+            new McpVersionStorageContents(bytes(JacksonUtils.toJson(firstServer)), null, null),
+            new McpVersionStorageContents(bytes(JacksonUtils.toJson(fullServer)), tools,
+                resources));
+    }
+    
+    private McpServerStorageInfo server(String version) {
+        McpServerStorageInfo result = new McpServerStorageInfo();
+        result.setId(MCP_ID);
+        result.setName(MCP_NAME);
+        result.setDescription("legacy description");
+        ServerVersionDetail detail = new ServerVersionDetail();
+        detail.setVersion(version);
+        result.setVersionDetail(detail);
+        result.setToolsDescriptionRef(McpConfigUtils.formatServerToolSpecDataId(MCP_ID, version));
+        result.setResourceDescriptionRef(
+            McpConfigUtils.formatServerResourceSpecDataId(MCP_ID, version));
+        return result;
+    }
+    
+    private McpServerVersionInfo manifest(String... versions) {
+        McpServerVersionInfo result = new McpServerVersionInfo();
+        result.setId(MCP_ID);
+        result.setName(MCP_NAME);
+        result.setDescription("legacy description");
+        result.setEnabled(true);
+        List<ServerVersionDetail> details = new ArrayList<>();
+        for (String version : versions) {
+            ServerVersionDetail detail = new ServerVersionDetail();
+            detail.setVersion(version);
+            details.add(detail);
+        }
+        result.setVersions(details);
+        if (versions.length > 0) {
+            result.setLatestPublishedVersion(versions[versions.length - 1]);
+        }
+        return result;
+    }
+    
+    private AiResource expectedResource(McpServerVersionInfo manifest, int onlineCount) {
+        McpResourceExt ext = new McpResourceExt();
+        ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        ext.setMcpId(MCP_ID);
+        ResourceVersionInfo versionInfo = new ResourceVersionInfo();
+        versionInfo.setOnlineCnt(onlineCount);
+        versionInfo.setLabels(Collections.singletonMap(AiResourceConstants.LABEL_LATEST,
+            manifest.getLatestPublishedVersion()));
+        AiResource result = new AiResource();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setName(MCP_NAME);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        result.setDesc(manifest.getDescription());
+        result.setStatus(manifest.isEnabled() ? AiResourceConstants.META_STATUS_ENABLE
+            : AiResourceConstants.META_STATUS_DISABLE);
+        result.setBizTags("[]");
+        result.setExt(McpResourceExtSerializer.serialize(ext));
+        result.setFrom(McpHistoricalResourceReconciler.LEGACY_SOURCE);
+        result.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        result.setMetaVersion(1L);
+        result.setScope(VisibilityConstants.SCOPE_PUBLIC);
+        result.setOwner("nacos");
+        return result;
+    }
+    
+    private AiResourceVersion expectedVersion(String version) {
+        McpVersionStorageDescriptor descriptor = McpVersionStorageKeyComposer.fromLegacy(
+            NAMESPACE_ID, MCP_ID, version, server(version));
+        AiResourceVersion result = new AiResourceVersion();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setName(MCP_NAME);
+        result.setType(AiResourceConstants.RESOURCE_TYPE_MCP);
+        result.setVersion(version);
+        result.setStatus(AiResourceConstants.VERSION_STATUS_ONLINE);
+        result.setAuthor("nacos");
+        result.setDesc("");
+        result.setStorage(McpVersionStorageDescriptorSerializer.serialize(descriptor));
+        return result;
+    }
+    
+    private void assertResource(AiResource resource, McpServerVersionInfo manifest,
+        int onlineCount) {
+        assertEquals(NAMESPACE_ID, resource.getNamespaceId());
+        assertEquals(MCP_NAME, resource.getName());
+        assertEquals(AiResourceConstants.RESOURCE_TYPE_MCP, resource.getType());
+        assertEquals(McpHistoricalResourceReconciler.LEGACY_SOURCE, resource.getFrom());
+        assertEquals("nacos", resource.getOwner());
+        assertEquals(VisibilityConstants.SCOPE_PUBLIC, resource.getScope());
+        assertEquals(MCP_ID, McpResourceExtSerializer.deserialize(resource.getExt()).getMcpId());
+        ResourceVersionInfo versionInfo = JacksonUtils.toObj(resource.getVersionInfo(),
+            ResourceVersionInfo.class);
+        assertEquals(onlineCount, versionInfo.getOnlineCnt());
+        assertEquals(manifest.getLatestPublishedVersion(),
+            versionInfo.getLabels().get(AiResourceConstants.LABEL_LATEST));
+    }
+    
+    private byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+    
+    private <T> Page<T> page(List<T> items, int totalCount, int pagesAvailable) {
+        Page<T> result = new Page<>();
+        result.setPageItems(items);
+        result.setTotalCount(totalCount);
+        result.setPagesAvailable(pagesAvailable);
+        return result;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconcilerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpHistoricalResourceReconcilerTest.java
@@ -55,6 +55,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -128,6 +129,25 @@ class McpHistoricalResourceReconcilerTest {
         assertResource(resourceCaptor.getValue(), manifest, 2);
         verify(versionStorageService, never()).save(any(), any());
         verify(versionStorageService, never()).delete(any());
+    }
+    
+    @Test
+    void testReconcileAcceptsManifestWithoutDescription() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        manifest.setDescription(null);
+        stubStorage(VERSION);
+        stubEmptyResource();
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(Collections.emptyList(), 0, 0));
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(1L);
+        when(resourcePersistService.insert(any(AiResource.class))).thenReturn(1L);
+        
+        assertEquals(2, reconciler.reconcile(NAMESPACE_ID, manifest));
+        
+        ArgumentCaptor<AiResource> captor = ArgumentCaptor.forClass(AiResource.class);
+        verify(resourcePersistService).insert(captor.capture());
+        assertNull(captor.getValue().getDesc());
     }
     
     @Test
@@ -382,6 +402,54 @@ class McpHistoricalResourceReconcilerTest {
     }
     
     @Test
+    void testReconcileRejectsNullAndInconsistentResourceQueryRows() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        Page<AiResource> nullItems = new Page<>();
+        nullItems.setPageItems(null);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(nullItems);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        reset(resourcePersistService);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList((AiResource) null), 1, 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        reset(resourcePersistService);
+        AiResource wrongName = expectedResource(manifest, 1);
+        wrongName.setName("other");
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(wrongName), 1, 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        reset(resourcePersistService);
+        AiResource wrongType = expectedResource(manifest, 1);
+        wrongType.setType(AiResourceConstants.RESOURCE_TYPE_SKILL);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Collections.singletonList(wrongType), 1, 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        reset(resourcePersistService);
+        AiResource first = expectedResource(manifest, 1);
+        AiResource second = expectedResource(manifest, 1);
+        AiResource third = expectedResource(manifest, 1);
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(Arrays.asList(first, second, third), 3, 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+    }
+    
+    @Test
     void testReconcileRejectsExtraOrConflictingVersionRows() throws Exception {
         McpServerVersionInfo manifest = manifest(VERSION);
         stubStorage(VERSION);
@@ -442,6 +510,33 @@ class McpHistoricalResourceReconcilerTest {
     }
     
     @Test
+    void testReconcileRejectsNullAndInconsistentVersionQueryRows() throws Exception {
+        McpServerVersionInfo manifest = manifest(VERSION);
+        stubStorage(VERSION);
+        stubEmptyResource();
+        Page<AiResourceVersion> nullItems = new Page<>();
+        nullItems.setPageItems(null);
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100)).thenReturn(nullItems);
+        assertEquals(NacosException.SERVER_ERROR,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
+        
+        assertVersionRowsRejected(Collections.singletonList(null), manifest);
+        AiResourceVersion wrongNamespace = expectedVersion(VERSION);
+        wrongNamespace.setNamespaceId("other");
+        assertVersionRowsRejected(Collections.singletonList(wrongNamespace), manifest);
+        AiResourceVersion wrongType = expectedVersion(VERSION);
+        wrongType.setType(AiResourceConstants.RESOURCE_TYPE_SKILL);
+        assertVersionRowsRejected(Collections.singletonList(wrongType), manifest);
+        AiResourceVersion blankVersion = expectedVersion(VERSION);
+        blankVersion.setVersion(" ");
+        assertVersionRowsRejected(Collections.singletonList(blankVersion), manifest);
+        assertVersionRowsRejected(Arrays.asList(expectedVersion(VERSION),
+            expectedVersion(VERSION)), manifest);
+    }
+    
+    @Test
     void testReconcileRejectsInvalidManifestShapesBeforeStorageAccess() {
         assertInvalidManifest(null);
         assertEquals(NacosException.CONFLICT,
@@ -476,6 +571,9 @@ class McpHistoricalResourceReconcilerTest {
         assertInvalidManifest(invalid);
         invalid = manifest(VERSION);
         invalid.setLatestPublishedVersion("other");
+        assertInvalidManifest(invalid);
+        invalid = manifest(VERSION);
+        invalid.setLatestPublishedVersion(null);
         assertInvalidManifest(invalid);
         verifyNoInteractions(versionStorageService, resourcePersistService,
             versionPersistService);
@@ -555,6 +653,17 @@ class McpHistoricalResourceReconcilerTest {
         when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
             AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
             .thenReturn(page(versions, versions.size(), 1));
+    }
+    
+    private void assertVersionRowsRejected(List<AiResourceVersion> versions,
+        McpServerVersionInfo manifest) throws Exception {
+        reset(versionPersistService);
+        when(versionPersistService.list(NAMESPACE_ID, MCP_NAME,
+            AiResourceConstants.RESOURCE_TYPE_MCP, null, 1, 100))
+            .thenReturn(page(versions, versions.size(), 1));
+        assertEquals(NacosException.CONFLICT,
+            assertThrows(NacosException.class,
+                () -> reconciler.reconcile(NAMESPACE_ID, manifest)).getErrCode());
     }
     
     private void stubEmptyResource() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocatorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/McpResourceLocatorTest.java
@@ -132,6 +132,70 @@ class McpResourceLocatorTest {
     }
     
     @Test
+    void testLocateByNameHandlesNullPageAndInconsistentDuplicateRows() {
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(null);
+        NacosApiException missing = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "demo", null));
+        assertEquals(NacosException.NOT_FOUND, missing.getErrCode());
+        
+        List<AiResource> duplicates = Arrays.asList(resource("public", "demo", MCP_ID),
+            resource("public", "demo", OTHER_MCP_ID));
+        when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+            .thenReturn(page(1, 1, duplicates));
+        NacosApiException conflict = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", "demo", null));
+        assertEquals(NacosException.CONFLICT, conflict.getErrCode());
+    }
+    
+    @Test
+    void testLocateByIdRejectsInvalidPageResponses() {
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(null);
+        assertIntegrityFailure(() -> locator.locate("public", null, MCP_ID));
+        
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(page(0, 0, (List<AiResource>) null));
+        assertIntegrityFailure(() -> locator.locate("public", null, MCP_ID));
+    }
+    
+    @Test
+    void testLocateByIdCalculatesPagesFromTotalCount() throws Exception {
+        Page<AiResource> first = page(101, 0,
+            resource("public", "other", OTHER_MCP_ID));
+        Page<AiResource> second = page(101, 0, resource("public", "demo", MCP_ID));
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(first, second);
+        
+        assertEquals("demo", locator.locate("public", null, MCP_ID).getName());
+        verify(resourcePersistService, times(2))
+            .list(any(QueryCondition.class), anyInt(), eq(100));
+    }
+    
+    @Test
+    void testLocateByIdReturnsControlledNotFound() {
+        when(resourcePersistService.list(any(QueryCondition.class), anyInt(), eq(100)))
+            .thenReturn(page(0, 0, Collections.emptyList()));
+        NacosApiException missing = assertThrows(NacosApiException.class,
+            () -> locator.locate("public", null, MCP_ID));
+        assertEquals(NacosException.NOT_FOUND, missing.getErrCode());
+        assertEquals(ErrorCode.MCP_SERVER_NOT_FOUND.getCode(), missing.getDetailErrCode());
+    }
+    
+    @Test
+    void testLocateRejectsInconsistentRows() {
+        AiResource wrongNamespace = resource("other", "demo", MCP_ID);
+        AiResource wrongType = resource("public", "demo", MCP_ID);
+        wrongType.setType("skill");
+        AiResource wrongName = resource("public", "other", MCP_ID);
+        for (AiResource invalid : Arrays.asList(null, wrongNamespace, wrongType, wrongName)) {
+            when(resourcePersistService.list(any(QueryCondition.class), eq(1), eq(2)))
+                .thenReturn(page(1, 1, invalid));
+            assertIntegrityFailure(() -> locator.locate("public", "demo", null));
+        }
+    }
+    
+    @Test
     void testLocateRejectsMalformedStoredExtension() {
         AiResource invalid = resource("public", "demo", MCP_ID);
         invalid.setExt("{\"schemaVersion\":1}");
@@ -196,5 +260,16 @@ class McpResourceLocatorTest {
         result.setPagesAvailable(pagesAvailable);
         result.setPageItems(resources);
         return result;
+    }
+    
+    private void assertIntegrityFailure(ThrowingLocatorCall call) {
+        NacosApiException conflict = assertThrows(NacosApiException.class, call::locate);
+        assertEquals(NacosException.CONFLICT, conflict.getErrCode());
+        assertEquals(ErrorCode.RESOURCE_CONFLICT.getCode(), conflict.getDetailErrCode());
+    }
+    
+    private interface ThrowingLocatorCall {
+        
+        void locate() throws NacosApiException;
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupportTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpJsonValidationSupportTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.mcp.storage;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpJsonValidationSupportTest {
+    
+    private static final String CONTRACT_NAME = "test contract";
+    
+    @Test
+    void testParseWrapsJacksonDeserializationFailure() {
+        try (MockedStatic<JacksonUtils> jacksonMock = Mockito.mockStatic(JacksonUtils.class)) {
+            jacksonMock.when(() -> JacksonUtils.toObj("{}", Object.class))
+                .thenThrow(new NacosDeserializationException());
+            assertThrows(IllegalArgumentException.class,
+                () -> McpJsonValidationSupport.parseSingleValue("{}", CONTRACT_NAME));
+        }
+    }
+    
+    @Test
+    void testRejectUnknownNonStringField() {
+        Map<Object, Object> object = new LinkedHashMap<>();
+        object.put(1, "value");
+        assertThrows(IllegalArgumentException.class,
+            () -> McpJsonValidationSupport.rejectUnknownFields(object,
+                Collections.singleton("known"), CONTRACT_NAME));
+    }
+    
+    @Test
+    void testRequireIntegerSupportsIntegralTypes() {
+        Map<String, Object> object = new LinkedHashMap<>();
+        for (Number value : new Number[] {(byte) 1, (short) 2, 3, 4L}) {
+            object.put("value", value);
+            assertEquals(value.intValue(), McpJsonValidationSupport.requireInteger(object,
+                "value", CONTRACT_NAME));
+        }
+        object.put("value", 1.0D);
+        assertThrows(IllegalArgumentException.class,
+            () -> McpJsonValidationSupport.requireInteger(object, "value", CONTRACT_NAME));
+    }
+    
+    @Test
+    void testRequireIntegerRejectsOutOfRangeLong() {
+        Map<String, Object> object = new LinkedHashMap<>();
+        object.put("value", (long) Integer.MAX_VALUE + 1L);
+        assertThrows(IllegalArgumentException.class,
+            () -> McpJsonValidationSupport.requireInteger(object, "value", CONTRACT_NAME));
+        object.put("value", (long) Integer.MIN_VALUE - 1L);
+        assertThrows(IllegalArgumentException.class,
+            () -> McpJsonValidationSupport.requireInteger(object, "value", CONTRACT_NAME));
+    }
+    
+    @Test
+    void testStrictParserRejectsWhitespaceOnlyInput() {
+        assertThrows(IllegalArgumentException.class,
+            () -> McpJsonValidationSupport.parseSingleValue("   ", CONTRACT_NAME));
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpResourceExtSerializerTest.java
@@ -17,7 +17,11 @@
 package com.alibaba.nacos.ai.service.mcp.storage;
 
 import com.alibaba.nacos.ai.model.mcp.McpResourceExt;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,6 +63,19 @@ class McpResourceExtSerializerTest {
         ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
         ext.setMcpId("not-a-uuid");
         assertThrows(IllegalArgumentException.class, () -> McpResourceExtSerializer.serialize(ext));
+    }
+    
+    @Test
+    void testSerializeWrapsJacksonFailure() {
+        McpResourceExt ext = new McpResourceExt();
+        ext.setSchemaVersion(McpResourceExt.SCHEMA_VERSION);
+        ext.setMcpId(MCP_ID);
+        try (MockedStatic<JacksonUtils> jacksonMock = Mockito.mockStatic(JacksonUtils.class)) {
+            jacksonMock.when(() -> JacksonUtils.toJson(Mockito.any()))
+                .thenThrow(new NacosSerializationException());
+            assertThrows(IllegalArgumentException.class,
+                () -> McpResourceExtSerializer.serialize(ext));
+        }
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.ai.service.mcp.storage;
 
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.service.SyncEffectService;
+import com.alibaba.nacos.ai.service.mcp.storage.McpServingManifestStorage.ReconciliationPage;
 import com.alibaba.nacos.ai.utils.McpConfigUtils;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -40,11 +41,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -153,11 +156,12 @@ class McpServingManifestStorageTest {
             Constants.ALL_PATTERN, Constants.MCP_SERVER_VERSIONS_GROUP, "public",
             Collections.emptyMap())).thenReturn(page);
         
-        Page<McpServerVersionInfo> result = storage.list("public", 2, 2);
+        ReconciliationPage result = storage.list("public", 2, 2);
         
         assertEquals(2, result.getPageNumber());
         assertEquals(3, result.getPagesAvailable());
         assertEquals(5, result.getTotalCount());
+        assertTrue(result.getFailures().isEmpty());
         assertEquals("public", result.getPageItems().get(0).getNamespaceId());
         assertEquals(MCP_ID, result.getPageItems().get(0).getId());
     }
@@ -177,7 +181,7 @@ class McpServingManifestStorageTest {
     }
     
     @Test
-    void testListRejectsMissingPageItemsAndInvalidRows() {
+    void testListRejectsMissingPageItemsAndRecordsInvalidRows() throws Exception {
         when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
             any(), any(), any())).thenReturn(null);
         assertEquals("MCP serving Manifest query returned no page",
@@ -193,34 +197,42 @@ class McpServingManifestStorageTest {
         Page<ConfigInfo> nullRow = configPage(null);
         when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
             any(), any(), any())).thenReturn(nullRow);
-        assertEquals("MCP serving Manifest page contains an empty row",
-            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+        ReconciliationPage result = storage.list("public", 1, 1);
+        assertTrue(result.getPageItems().isEmpty());
+        assertEquals(1, result.getFailures().size());
+        assertTrue(result.getFailures().get(0).contains("<unknown>"));
     }
     
     @Test
-    void testListRejectsMalformedContentAndCoordinateMismatch() {
+    void testListContinuesAfterMalformedContentAndCoordinateMismatch() throws Exception {
         ConfigInfo malformed = new ConfigInfo();
         malformed.setDataId(McpConfigUtils.formatServerVersionInfoDataId(MCP_ID));
         malformed.setGroup(Constants.MCP_SERVER_VERSIONS_GROUP);
         malformed.setContent("not-json");
-        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
-            any(), any(), any())).thenReturn(configPage(malformed));
-        assertEquals("MCP serving Manifest page contains invalid content",
-            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
-        
         ConfigInfo wrongDataId = configInfo(manifest());
         wrongDataId.setDataId("wrong");
-        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
-            any(), any(), any())).thenReturn(configPage(wrongDataId));
-        assertEquals("MCP serving Manifest identity does not match its Config coordinate",
-            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
-        
         ConfigInfo wrongGroup = configInfo(manifest());
         wrongGroup.setGroup("wrong");
+        McpServerVersionInfo validManifest = manifest();
+        validManifest.setName("valid");
+        ConfigInfo valid = configInfo(validManifest);
+        Page<ConfigInfo> page = new Page<>();
+        page.setPageItems(Arrays.asList(malformed, valid, wrongDataId, wrongGroup));
+        page.setTotalCount(4);
+        page.setPagesAvailable(1);
         when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
-            any(), any(), any())).thenReturn(configPage(wrongGroup));
-        assertEquals("MCP serving Manifest identity does not match its Config coordinate",
-            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+            any(), any(), any())).thenReturn(page);
+        
+        ReconciliationPage result = storage.list("public", 1, 10);
+        
+        assertEquals(1, result.getPageItems().size());
+        assertEquals("valid", result.getPageItems().get(0).getName());
+        assertEquals(3, result.getFailures().size());
+        assertTrue(result.getFailures().stream().anyMatch(message -> message.contains("wrong")));
+        assertTrue(result.getFailures().stream()
+            .anyMatch(message -> message.contains("invalid content")));
+        assertTrue(result.getFailures().stream()
+            .anyMatch(message -> message.contains("identity does not match")));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpServingManifestStorageTest.java
@@ -21,8 +21,12 @@ import com.alibaba.nacos.ai.service.SyncEffectService;
 import com.alibaba.nacos.ai.utils.McpConfigUtils;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
+import com.alibaba.nacos.config.server.service.ConfigDetailService;
 import com.alibaba.nacos.config.server.service.ConfigOperationService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
@@ -31,13 +35,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
@@ -58,6 +67,9 @@ class McpServingManifestStorageTest {
     private ConfigOperationService configOperationService;
     
     @Mock
+    private ConfigDetailService configDetailService;
+    
+    @Mock
     private SyncEffectService syncEffectService;
     
     private McpServingManifestStorage storage;
@@ -65,7 +77,7 @@ class McpServingManifestStorageTest {
     @BeforeEach
     void setUp() {
         storage = new McpServingManifestStorage(configQueryChainService,
-            configOperationService, syncEffectService);
+            configOperationService, configDetailService, syncEffectService);
     }
     
     @Test
@@ -97,6 +109,22 @@ class McpServingManifestStorageTest {
     }
     
     @Test
+    void testGetRejectsMissingOrConflictingQueryResponse() {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(null);
+        assertEquals("MCP serving Manifest query returned no response",
+            assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+        
+        ConfigQueryChainResponse conflict = new ConfigQueryChainResponse();
+        conflict.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_QUERY_CONFLICT);
+        conflict.setMessage("conflict");
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(conflict);
+        assertEquals("MCP serving Manifest cannot be read: conflict",
+            assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+    }
+    
+    @Test
     void testGetRejectsMalformedOrConflictingManifest() {
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
             .thenReturn(foundResponse("not-json"));
@@ -112,6 +140,87 @@ class McpServingManifestStorageTest {
             .thenReturn(foundResponse("{}"));
         assertEquals("MCP serving Manifest has invalid identity fields",
             assertThrows(NacosException.class, () -> storage.get("public", MCP_ID)).getErrMsg());
+    }
+    
+    @Test
+    void testListPagesAndValidatesManifestCoordinates() throws Exception {
+        Page<ConfigInfo> page = new Page<>();
+        page.setPageNumber(2);
+        page.setPagesAvailable(3);
+        page.setTotalCount(5);
+        page.setPageItems(Collections.singletonList(configInfo(manifest())));
+        when(configDetailService.findConfigInfoPage(Constants.MCP_LIST_SEARCH_BLUR, 2, 2,
+            Constants.ALL_PATTERN, Constants.MCP_SERVER_VERSIONS_GROUP, "public",
+            Collections.emptyMap())).thenReturn(page);
+        
+        Page<McpServerVersionInfo> result = storage.list("public", 2, 2);
+        
+        assertEquals(2, result.getPageNumber());
+        assertEquals(3, result.getPagesAvailable());
+        assertEquals(5, result.getTotalCount());
+        assertEquals("public", result.getPageItems().get(0).getNamespaceId());
+        assertEquals(MCP_ID, result.getPageItems().get(0).getId());
+    }
+    
+    @Test
+    void testListRejectsInvalidPageAndStorageFailures() {
+        assertThrows(IllegalArgumentException.class, () -> storage.list("public", 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> storage.list("public", 1, 0));
+        assertThrows(IllegalArgumentException.class,
+            () -> storage.list("invalid namespace", 1, 1));
+        verifyNoInteractions(configDetailService);
+        
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenThrow(new IllegalStateException("failed"));
+        assertEquals("MCP serving Manifest page cannot be read",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+    }
+    
+    @Test
+    void testListRejectsMissingPageItemsAndInvalidRows() {
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(null);
+        assertEquals("MCP serving Manifest query returned no page",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+        
+        Page<ConfigInfo> missingItems = new Page<>();
+        missingItems.setPageItems(null);
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(missingItems);
+        assertEquals("MCP serving Manifest query returned no page",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+        
+        Page<ConfigInfo> nullRow = configPage(null);
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(nullRow);
+        assertEquals("MCP serving Manifest page contains an empty row",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+    }
+    
+    @Test
+    void testListRejectsMalformedContentAndCoordinateMismatch() {
+        ConfigInfo malformed = new ConfigInfo();
+        malformed.setDataId(McpConfigUtils.formatServerVersionInfoDataId(MCP_ID));
+        malformed.setGroup(Constants.MCP_SERVER_VERSIONS_GROUP);
+        malformed.setContent("not-json");
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(configPage(malformed));
+        assertEquals("MCP serving Manifest page contains invalid content",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+        
+        ConfigInfo wrongDataId = configInfo(manifest());
+        wrongDataId.setDataId("wrong");
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(configPage(wrongDataId));
+        assertEquals("MCP serving Manifest identity does not match its Config coordinate",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
+        
+        ConfigInfo wrongGroup = configInfo(manifest());
+        wrongGroup.setGroup("wrong");
+        when(configDetailService.findConfigInfoPage(any(), anyInt(), anyInt(), any(),
+            any(), any(), any())).thenReturn(configPage(wrongGroup));
+        assertEquals("MCP serving Manifest identity does not match its Config coordinate",
+            assertThrows(NacosException.class, () -> storage.list("public", 1, 1)).getErrMsg());
     }
     
     @Test
@@ -147,6 +256,36 @@ class McpServingManifestStorageTest {
     }
     
     @Test
+    void testPublishRejectsNullManifestBeforeConfigAccess() {
+        assertThrows(IllegalArgumentException.class, () -> storage.publish("public", null));
+        verifyNoInteractions(configOperationService, syncEffectService);
+    }
+    
+    @Test
+    void testPublishWorksWithoutSyncEffectService() throws Exception {
+        McpServingManifestStorage storageWithoutSync = new McpServingManifestStorage(
+            configQueryChainService, configOperationService, configDetailService, null);
+        
+        storageWithoutSync.publish("public", manifest());
+        
+        verify(configOperationService).publishConfig(any(ConfigFormV3.class), any(), isNull());
+        verifyNoInteractions(syncEffectService);
+    }
+    
+    @Test
+    void testPublishWrapsSerializationFailure() {
+        McpServerVersionInfo manifest = manifest();
+        try (MockedStatic<JacksonUtils> jacksonMock = Mockito.mockStatic(JacksonUtils.class)) {
+            jacksonMock.when(() -> JacksonUtils.toJson(manifest))
+                .thenThrow(new NacosSerializationException());
+            assertEquals("MCP serving Manifest cannot be encoded",
+                assertThrows(NacosException.class,
+                    () -> storage.publish("public", manifest)).getErrMsg());
+        }
+        verifyNoInteractions(configOperationService, syncEffectService);
+    }
+    
+    @Test
     void testDeleteUsesExistingCoordinate() throws Exception {
         storage.delete("public", MCP_ID);
         verify(configOperationService).deleteConfig(
@@ -176,4 +315,21 @@ class McpServingManifestStorageTest {
         result.setContent(content);
         return result;
     }
+    
+    private ConfigInfo configInfo(McpServerVersionInfo manifest) {
+        ConfigInfo result = new ConfigInfo();
+        result.setDataId(McpConfigUtils.formatServerVersionInfoDataId(manifest.getId()));
+        result.setGroup(Constants.MCP_SERVER_VERSIONS_GROUP);
+        result.setContent(JacksonUtils.toJson(manifest));
+        return result;
+    }
+    
+    private Page<ConfigInfo> configPage(ConfigInfo configInfo) {
+        Page<ConfigInfo> result = new Page<>();
+        result.setPageItems(Collections.singletonList(configInfo));
+        result.setTotalCount(1);
+        result.setPagesAvailable(1);
+        return result;
+    }
+    
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageDescriptorSerializerTest.java
@@ -16,8 +16,13 @@
 
 package com.alibaba.nacos.ai.service.mcp.storage;
 
+import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.model.mcp.McpVersionStorageDescriptor;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -80,6 +85,7 @@ class McpVersionStorageDescriptorSerializerTest {
         assertInvalidDescriptorValue(value -> value.setProvider("object-store"));
         assertInvalidDescriptorValue(value -> value.setKeyFormat("other"));
         assertInvalidDescriptorValue(value -> value.setSchemaVersion(2));
+        assertInvalidDescriptorValue(value -> value.setServerKey(null));
         assertInvalidDescriptorValue(
             value -> value.setServerKey("public:mcp-tools:x-mcp-tools.json"));
         assertInvalidDescriptorValue(
@@ -90,6 +96,26 @@ class McpVersionStorageDescriptorSerializerTest {
             "other:mcp-resources:x-mcp-resources.json"));
         assertInvalidDescriptorValue(value -> value.setServerKey(
             repeat("a", 1025) + ":mcp-server:x-mcp-server.json"));
+    }
+    
+    @Test
+    void testRejectMalformedStorageCoordinates() {
+        assertInvalidServerKey(":mcp-server:x-mcp-server.json");
+        assertInvalidServerKey("public::x-mcp-server.json");
+        assertInvalidServerKey("public:mcp-server:");
+        assertInvalidServerKey("public:mcp-server:" + Constants.MCP_SERVER_SPEC_DATA_ID_SUFFIX);
+        assertInvalidServerKey("public:mcp-server:long-invalid-server-coordinate.json");
+    }
+    
+    @Test
+    void testSerializeWrapsJacksonFailure() {
+        McpVersionStorageDescriptor descriptor = descriptor();
+        try (MockedStatic<JacksonUtils> jacksonMock = Mockito.mockStatic(JacksonUtils.class)) {
+            jacksonMock.when(() -> JacksonUtils.toJson(Mockito.any()))
+                .thenThrow(new NacosSerializationException());
+            assertThrows(IllegalArgumentException.class,
+                () -> McpVersionStorageDescriptorSerializer.serialize(descriptor));
+        }
     }
     
     @Test
@@ -119,6 +145,13 @@ class McpVersionStorageDescriptorSerializerTest {
     private void assertInvalidJson(String json) {
         assertThrows(IllegalArgumentException.class,
             () -> McpVersionStorageDescriptorSerializer.deserialize(json));
+    }
+    
+    private void assertInvalidServerKey(String key) {
+        assertThrows(IllegalArgumentException.class,
+            () -> McpVersionStorageDescriptorSerializer.parseKey(key,
+                Constants.MCP_SERVER_GROUP, Constants.MCP_SERVER_SPEC_DATA_ID_SUFFIX,
+                "serverKey"));
     }
     
     private McpVersionStorageDescriptor descriptor() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/mcp/storage/McpVersionStorageKeyComposerTest.java
@@ -84,6 +84,8 @@ class McpVersionStorageKeyComposerTest {
         assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
             "public", "invalid", "1.0.0", false, false));
         assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
+            "public", MCP_ID, null, false, false));
+        assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
             "public", MCP_ID, "", false, false));
         assertThrows(IllegalArgumentException.class, () -> McpVersionStorageKeyComposer.compose(
             "public", MCP_ID, repeat("v", 65), false, false));

--- a/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
@@ -36,6 +36,7 @@ import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -368,6 +369,9 @@ class NacosConfigAiResourceStorageTest {
     
     @Test
     void testParseInvalidFormatThrows() {
+        StorageKey singlePartKey = new StorageKey(NacosConfigAiResourceStorage.TYPE, "single");
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(singlePartKey));
         StorageKey key = new StorageKey(NacosConfigAiResourceStorage.TYPE, "only:two");
         assertThrows(IllegalArgumentException.class, () -> NacosConfigAiResourceStorage.parse(key));
     }
@@ -678,6 +682,8 @@ class NacosConfigAiResourceStorageTest {
         for (int i = 0; i < expectedTypes.size(); i++) {
             assertEquals(expectedTypes.get(i), formCaptor.getAllValues().get(i).getType());
         }
+        assertEquals(ConfigType.TEXT.getType(), ReflectionTestUtils.invokeMethod(
+            NacosConfigAiResourceStorage.class, "guessConfigType", ""));
     }
     
     @Test

--- a/specs/en/ai/mcp-server-spec.md
+++ b/specs/en/ai/mcp-server-spec.md
@@ -446,8 +446,11 @@ content = {"schemaVersion":1,"state":"LIFECYCLE_MANAGED","completedAt":<epochMil
 
 The permanent marker means management rows are completely hosted. It does not
 authorize deletion or mutation of serving Config or Naming data. A renewable
-cluster lease may use a separate internal Config key. Losing the lease stops
-the current writer without deleting MCP content.
+cluster lease uses `nacos.ai.mcp.resource.reconciliation.lease.v1`. While the
+system is still synchronizing, the task may persist non-authoritative
+diagnostics at `nacos.ai.mcp.resource.reconciliation.progress.v1` with
+`state=SYNCING`. Neither object is the completion marker. Losing the lease
+stops the current writer without deleting MCP content.
 
 ### 8.2 Reconciliation
 
@@ -466,14 +469,22 @@ After the root `ApplicationReadyEvent`, a background task:
    `mcpName`;
 7. detects missing content, conflicting identity, duplicate source rows,
    invalid Versions, and pending deletion;
-8. reconciles removed `legacy-mcp` rows without deleting independently
-   created resources;
+8. routes removed `legacy-mcp` rows through the common lifecycle
+   delete/recovery flow without deleting independently created resources;
 9. completes a zero-difference validation round; and
 10. writes the completion marker only after every known cluster member supports
     managed writes and write-after-reconcile hooks.
 
-Reconciliation creates pointers only. It never saves or rewrites historical
-payloads and never mutates Naming.
+The Version/Resource upsert phase creates pointers only. It never saves or
+rewrites historical payloads and never mutates Naming. Until the canonical
+name Search projector and the common lifecycle delete/recovery handlers are
+available on every member, a `SYNCING` reconciler records Search backfill,
+extra Version, and orphaned `legacy-mcp` work as blocking diagnostics. It must
+not enqueue an ID-keyed Search task or directly delete Resource/Version rows,
+payload Config, or Naming state. Such a partial synchronization can never
+write the completion marker. Before the name-keyed projector is introduced,
+the progress record keeps `searchBackfillPending=true` and
+`managedCutoverReady=false` even when lifecycle rows have zero difference.
 
 ### 8.3 Writes During `SYNCING`
 

--- a/specs/zh-cn/ai/mcp-server-spec.md
+++ b/specs/zh-cn/ai/mcp-server-spec.md
@@ -377,7 +377,10 @@ content = {"schemaVersion":1,"state":"LIFECYCLE_MANAGED","completedAt":<epochMil
 ```
 
 该永久 Marker 表示管理 row 已完整托管，不授权删除或修改 Serving Config/Naming 数据。
-可续约集群 Lease 可以使用独立内部 Config Key；失去 Lease 只停止当前 Writer，不删除 MCP 内容。
+可续约集群 Lease 使用 `nacos.ai.mcp.resource.reconciliation.lease.v1`。系统仍在同步时，
+任务可以在 `nacos.ai.mcp.resource.reconciliation.progress.v1` 持久化
+`state=SYNCING` 的非权威诊断信息。两者都不是完成 Marker；失去 Lease 只停止当前 Writer，
+不删除 MCP 内容。
 
 ### 8.2 对账流程
 
@@ -392,11 +395,18 @@ content = {"schemaVersion":1,"state":"LIFECYCLE_MANAGED","completedAt":<epochMil
    `from=legacy-mcp`；
 6. 按标准 `mcpName` 调度共享异步 Search 对账；
 7. 检测内容缺失、身份冲突、多来源重复 row、非法 Version 和 pending delete；
-8. 对已删除的 `legacy-mcp` row 做对账，但不删除独立创建的资源；
+8. 通过通用生命周期 Delete/Recovery 流程处理已删除的 `legacy-mcp` row，
+   但不删除独立创建的资源；
 9. 完成一轮零差异校验；
 10. 只有所有已知集群成员都支持托管写入和写后对账 Hook 时才写完成 Marker。
 
-对账只创建指针，绝不保存或重写历史 payload，也不修改 Naming。
+Version/Resource Upsert 阶段只创建指针，绝不保存或重写历史 payload，也不修改 Naming。
+在所有 Member 都具备标准名称 Search Projector 和通用生命周期 Delete/Recovery Handler 前，
+`SYNCING` Reconciler 把 Search Backfill、额外 Version 和孤儿 `legacy-mcp` 工作记录为阻断性
+诊断；不得调度以 ID 为 Key 的 Search Task，也不得直接删除 Resource/Version Row、Payload
+Config 或 Naming 状态。该部分同步状态绝不能写入完成 Marker。在基于名称的 Projector
+落地前，即使生命周期 Row 已达到零差异，进度记录也保持 `searchBackfillPending=true` 和
+`managedCutoverReady=false`。
 
 ### 8.3 `SYNCING` 期间写入
 


### PR DESCRIPTION
## What is the purpose of the change

For #15761.

Continue #15761 by hosting historical MCP management metadata in the shared AI Resource lifecycle tables without changing the existing serving plane.

This is the historical reconciliation stage after #15774. It maps legacy MCP manifests and their existing Server/Tools/Resources Config coordinates into `ai_resource` and `ai_resource_version`, while management routes remain in `SYNCING`. No HTTP, gRPC, SDK, gateway, payload Config, or Naming contract changes in this pull request.

## Brief changelog

* add a cluster-singleton, renewable-lease reconciliation task started after the root application is ready;
* page all namespaces and serving manifests through `McpServingManifestStorage`;
* validate the historical manifest, Server, Tools, and Resources content before creating zero-copy storage descriptors;
* reconcile Versions first and Resource metadata last, with idempotent retry, CAS recovery, duplicate/conflict detection, and orphan diagnostics;
* persist non-authoritative `SYNCING` progress, including zero-difference, pending Search backfill, and a permanent `managedCutoverReady=false` guard;
* never rewrite historical payload bytes, mutate Naming, delete orphan rows, enqueue the old ID-keyed Search projection, or write the `LIFECYCLE_MANAGED` marker;
* update the English and Chinese MCP specs for the lease/progress contract and staged reconciliation boundary;
* add unit tests for the reconciler and lease/progress state machine, and close the missing/partial coverage reported by Codecov on #15774.

## Verifying this change

* `mvn -pl ai spotless:apply spotless:check`
* focused MCP/storage/reconciliation suite: 144 tests passed;
* repository pre-submission gate: all 62 modules passed `clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests`;
* focused JaCoCo results:
  * prior #15774 mapping/storage classes: 100% line coverage;
  * `McpHistoricalResourceReconciler`: 100% line, 78.5% branch coverage;
  * `McpLifecycleReconciliationTask`: 99.5% line, 80.6% branch coverage.

The full `ai` suite ran 2,376 tests. All changed tests passed; the pre-existing order-sensitive `OpenAiCompatibleResourceIndexEnhancementServiceTest` reported one failure and one error in the full-suite order, while its isolated rerun passed 7/7. The changed code does not access that test's configuration or system properties.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] A GitHub issue is filed for the change.
* [x] The pull request title follows the issue title convention.
* [x] The description explains the behavior and compatibility boundary.
* [x] Unit tests cover the new behavior and previous coverage gaps.
* [x] Spotless and the repository pre-submission checks pass.
