### PR TITLE
Add admin authentication to server state admin API

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerStateController.java
+++ b/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerStateController.java
@@ -18,11 +18,15 @@ package com.alibaba.nacos.core.controller.v3;
 
 import com.alibaba.nacos.api.annotation.Since;
 import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.core.cluster.health.ModuleHealthCheckerHolder;
 import com.alibaba.nacos.core.cluster.health.ReadinessResult;
 import com.alibaba.nacos.core.service.NacosServerStateService;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,6 +57,8 @@ public class ServerStateController {
      * @return state key-value map.
      */
     @Since("3.0.0")
+    @Secured(action = ActionTypes.READ, resource = NACOS_ADMIN_CORE_CONTEXT_V3
+        + "/state", signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
     @GetMapping()
     public Result<Map<String, String>> serverState() {
         return Result.success(stateService.getServerState());

--- a/core/src/test/java/com/alibaba/nacos/core/controller/v3/SecuredMetadataTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/controller/v3/SecuredMetadataTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SecuredMetadataTest {
     
@@ -36,6 +37,30 @@ class SecuredMetadataTest {
         assertConsoleSignType("smartReload");
         assertConsoleSignType("reloadSingle");
         assertConsoleSignType("loaderMetrics");
+    }
+    
+    @Test
+    void testServerStateRequiresAdminAuth() {
+        Method method = Arrays.stream(ServerStateController.class.getDeclaredMethods())
+            .filter(candidate -> "serverState".equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals("/v3/admin/core/state", secured.resource());
+        assertEquals(SignType.CONSOLE, secured.signType());
+        assertEquals(ApiType.ADMIN_API, secured.apiType());
+    }
+    
+    @Test
+    void testLivenessAndReadinessStayAnonymous() {
+        for (String methodName : new String[] {"liveness", "readiness"}) {
+            Method method = Arrays.stream(ServerStateController.class.getDeclaredMethods())
+                .filter(candidate -> methodName.equals(candidate.getName()))
+                .findFirst()
+                .orElseThrow();
+            assertNull(method.getAnnotation(Secured.class));
+        }
     }
     
     private void assertConsoleSignType(String methodName) {


### PR DESCRIPTION
## What is the purpose of the change

GET `/nacos/v3/admin/core/state` returns the server runtime state (version, startup mode, auth switches, quotas, etc.) without any authentication. Other endpoints under `/v3/admin/*` are protected by the AuthAdminFilter when `nacos.core.auth.admin.enabled=true` (default), but `ServerStateController#serverState` has no `@Secured` annotation, so the auth filter skips it and the state fingerprint is readable by anyone who can reach the server port.

## Brief changelog

- Add `@Secured` (ADMIN_API, read) to `ServerStateController#serverState`, consistent with other core admin controllers
- Keep `/liveness` and `/readiness` anonymous: the client SDK health check (`NamingHttpClientProxy`) and Kubernetes probes depend on them

## Verifying this change

- Extended `SecuredMetadataTest`: `serverState` must be secured with ADMIN_API; `liveness`/`readiness` must stay annotation-free.
- Manually verified on a local 3.2.4 standalone build: anonymous `GET /nacos/v3/admin/core/state` returns 403 after the change (200 before), `/liveness` stays 200, and the console login page (`/v3/console/server/state`) is unaffected.
- `mvn -B package -DskipTests` passes.
