### PR TITLE
Add network boundary check to legacy MCP URL import

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
@@ -19,9 +19,15 @@ package com.alibaba.nacos.ai.importer.security;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
 import org.springframework.stereotype.Service;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Locale;
 
 /**
  * Central guard for import artifacts crossing the plugin boundary.
@@ -31,6 +37,14 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class AiResourceImportSecurityGuard {
+    
+    private static final String HTTPS_SCHEME = "https";
+    
+    private static final String HTTP_SCHEME = "http";
+    
+    private static final String LOCALHOST = "localhost";
+    
+    private static final String LOCALHOST_SUFFIX = ".localhost";
     
     /**
      * Check artifact type and size before validation or import.
@@ -58,6 +72,68 @@ public class AiResourceImportSecurityGuard {
         if (maxArtifactSize > 0 && payloadSize > maxArtifactSize) {
             throw invalid("AI resource import artifact size exceeds plugin limit.");
         }
+    }
+    
+    /**
+     * Check a user provided URL before the server fetches it, e.g. through the
+     * legacy MCP import path.
+     *
+     * <p>The legacy path has no operator configured source to hold per-source
+     * network policies, so hosts resolving to private or local targets are
+     * always rejected; internal registries should be imported through
+     * configured import sources instead.
+     *
+     * @param endpoint user provided URL
+     * @throws NacosException if the endpoint violates the import boundary
+     */
+    public void checkUserEndpoint(String endpoint) throws NacosException {
+        if (StringUtils.isBlank(endpoint)) {
+            return;
+        }
+        URI parsed;
+        try {
+            parsed = URI.create(endpoint.trim());
+        } catch (IllegalArgumentException e) {
+            throw invalid("AI resource import request URL is invalid.");
+        }
+        String scheme = parsed.getScheme() == null ? null
+            : parsed.getScheme().toLowerCase(Locale.ENGLISH);
+        if (!HTTPS_SCHEME.equals(scheme) && !HTTP_SCHEME.equals(scheme)) {
+            throw invalid("AI resource import request URL must use http or https.");
+        }
+        if (StringUtils.isBlank(parsed.getHost())) {
+            throw invalid("AI resource import request URL host must not be empty.");
+        }
+        if (isUnsafeHost(parsed.getHost())) {
+            throw invalid(
+                "AI resource import request URL resolves to a private or local target.");
+        }
+    }
+    
+    private boolean isUnsafeHost(String host) throws NacosException {
+        String normalized = InternetAddressUtil.removeBrackets(host).toLowerCase(Locale.ENGLISH);
+        if (LOCALHOST.equals(normalized) || normalized.endsWith(LOCALHOST_SUFFIX)) {
+            return true;
+        }
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(normalized);
+        } catch (UnknownHostException e) {
+            throw invalid("AI resource import request URL host can not be resolved.");
+        }
+        for (InetAddress each : addresses) {
+            if (each.isAnyLocalAddress() || each.isLoopbackAddress()
+                || each.isLinkLocalAddress() || each.isSiteLocalAddress()
+                || each.isMulticastAddress() || isUniqueLocalIpv6Address(each)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isUniqueLocalIpv6Address(InetAddress address) {
+        byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc;
     }
     
     private NacosException invalid(String message) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpExternalDataAdaptor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpExternalDataAdaptor.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.ai.service;
 
 import com.alibaba.nacos.ai.enums.ExternalDataTypeEnum;
+import com.alibaba.nacos.ai.importer.security.AiResourceImportSecurityGuard;
 import com.alibaba.nacos.ai.model.mcp.UrlPageResult;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.FrontEndpointConfig;
@@ -68,6 +69,8 @@ import java.util.stream.Collectors;
 @Deprecated
 @Service
 public class McpExternalDataAdaptor {
+    
+    private final AiResourceImportSecurityGuard securityGuard = new AiResourceImportSecurityGuard();
     
     private HttpClient httpClient;
     
@@ -172,6 +175,7 @@ public class McpExternalDataAdaptor {
     
     private UrlPageResult fetchUrlPage(String urlData, String cursor, Integer limit, String search)
         throws Exception {
+        securityGuard.checkUserEndpoint(urlData);
         String base = urlData.trim();
         HttpClient client = getHttpClient();
         String pageUrl = buildPageUrl(base, cursor, limit, search);
@@ -485,7 +489,7 @@ public class McpExternalDataAdaptor {
     private HttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = HttpClient.newBuilder()
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
                 .build();
         }

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuardTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuardTest.java
@@ -52,6 +52,40 @@ class AiResourceImportSecurityGuardTest {
         assertThrows(NacosException.class, () -> guard.checkArtifact(1, "mcp", json));
     }
     
+    @Test
+    void testUserEndpointRejectsLocalAndPrivateTargets() {
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://127.0.0.1:8848/nacos"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://localhost:8848/nacos"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://sub.localhost/registry"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://10.0.0.5/registry"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://192.168.1.10/registry"));
+        assertThrows(NacosException.class,
+            () -> guard.checkUserEndpoint("http://169.254.169.254/latest/meta-data"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://[::1]/registry"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://[fc00::5]/registry"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http://224.0.0.1/registry"));
+    }
+    
+    @Test
+    void testUserEndpointAcceptsPublicTargets() {
+        assertDoesNotThrow(() -> guard.checkUserEndpoint("https://8.8.8.8/v0/servers"));
+        assertDoesNotThrow(() -> guard.checkUserEndpoint("http://100.64.0.1/v0/servers"));
+        assertDoesNotThrow(() -> guard.checkUserEndpoint("https://192.0.2.10:8443/v0/servers"));
+    }
+    
+    @Test
+    void testUserEndpointRejectsNonHttpSchemeAndBlankHost() {
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("file:///etc/passwd"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("ftp://192.0.2.10/registry"));
+        assertThrows(NacosException.class, () -> guard.checkUserEndpoint("http:///no-host/path"));
+    }
+    
+    @Test
+    void testUserEndpointIgnoresBlankValue() {
+        assertDoesNotThrow(() -> guard.checkUserEndpoint(""));
+        assertDoesNotThrow(() -> guard.checkUserEndpoint(null));
+    }
+    
     private AiResourceImportArtifact artifact(String resourceType) {
         AiResourceImportArtifact result = new AiResourceImportArtifact();
         result.setResourceType(resourceType);


### PR DESCRIPTION
## What is the purpose of the change

The legacy MCP import path (`McpExternalDataAdaptor`) fetches user provided URLs with its own HTTP client. Unlike the unified import plugins, whose `DefaultImportHttpClient` enforces a network boundary (scheme check, private/local target rejection), this legacy fetch runs without such a check, so an imported URL pointing at loopback/private/link-local targets is fetched by the server when `nacos.ai.resource.import.allow-user-url` is enabled. The client also follows redirects, so a public URL can lead the fetch to a blocked target.

## Brief changelog

- Add `checkUserEndpoint` to `AiResourceImportSecurityGuard`: resolves the URL host and rejects local/private targets (loopback, site-local, link-local, multicast, unique-local IPv6), consistent with `DefaultImportHttpClient` semantics
- Call the check before any fetch in `McpExternalDataAdaptor#fetchUrlPage`
- Stop following redirects (`Redirect.NEVER`) in the adaptor's HTTP client

## Verifying this change

- Extended `AiResourceImportSecurityGuardTest` with user-endpoint cases (local/private/link-local/multicast/unique-local rejection, public targets accepted, non-http scheme rejected). Existing `McpExternalDataAdaptorTest` and `McpLegacyImportAdapterTest` pass unchanged.
- `mvn -B test -pl ai -am` passes.
