### PR TITLE
[ISSUE #13690] Log resolved logging config location and add namespaceId to subscribe logs

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/logging/NacosLogging.java
+++ b/client/src/main/java/com/alibaba/nacos/client/logging/NacosLogging.java
@@ -91,11 +91,20 @@ public class NacosLogging {
         ScheduledExecutorService reloadContextService = ExecutorFactory.Managed
             .newSingleScheduledExecutorService("Nacos-Client",
                 new NameThreadFactory("com.alibaba.nacos.client.logging"));
-        reloadContextService.scheduleAtFixedRate(() -> {
-            if (loggingAdapter.isNeedReloadConfiguration()) {
-                loadConfiguration();
-            }
-        }, 0, loggingProperties.getReloadInternal(), TimeUnit.SECONDS);
+        reloadContextService.scheduleAtFixedRate(this::reloadConfigurationIfNeeded, 0,
+            loggingProperties.getReloadInternal(), TimeUnit.SECONDS);
+    }
+    
+    /**
+     * Reload the logging configuration when the adapter reports the config has changed.
+     *
+     * <p>All failures are handled inside {@link #loadConfiguration()}, so this task never throws and a faulty
+     * adapter can not cancel the periodic reload.
+     */
+    void reloadConfigurationIfNeeded() {
+        if (loggingAdapter.isNeedReloadConfiguration()) {
+            loadConfiguration();
+        }
     }
     
     private static class NacosLoggingInstance {

--- a/client/src/main/java/com/alibaba/nacos/client/logging/NacosLogging.java
+++ b/client/src/main/java/com/alibaba/nacos/client/logging/NacosLogging.java
@@ -42,6 +42,8 @@ public class NacosLogging {
     
     private NacosLoggingProperties loggingProperties;
     
+    private String lastLoadedConfigLocation;
+    
     private NacosLogging() {
         initLoggingAdapter();
     }
@@ -91,7 +93,7 @@ public class NacosLogging {
                 new NameThreadFactory("com.alibaba.nacos.client.logging"));
         reloadContextService.scheduleAtFixedRate(() -> {
             if (loggingAdapter.isNeedReloadConfiguration()) {
-                loggingAdapter.loadConfiguration(loggingProperties);
+                loadConfiguration();
             }
         }, 0, loggingProperties.getReloadInternal(), TimeUnit.SECONDS);
     }
@@ -112,11 +114,21 @@ public class NacosLogging {
         try {
             if (null != loggingAdapter) {
                 loggingAdapter.loadConfiguration(loggingProperties);
+                logLoadedConfigLocation();
             }
         } catch (Throwable t) {
             LOGGER.warn("Load {} Configuration of Nacos fail, message: {}",
                 LOGGER.getClass().getName(),
                 t.getMessage());
         }
+    }
+    
+    private void logLoadedConfigLocation() {
+        String configLocation = loggingProperties.getLocation();
+        if (null == configLocation || configLocation.equals(lastLoadedConfigLocation)) {
+            return;
+        }
+        lastLoadedConfigLocation = configLocation;
+        LOGGER.info("Nacos client logging configuration loaded from: {}", configLocation);
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
@@ -418,7 +418,8 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
     @Override
     public ServiceInfo subscribe(String serviceName, String groupName, String clusters)
         throws NacosException {
-        NAMING_LOGGER.info("[GRPC-SUBSCRIBE] service:{}, group:{}, cluster:{} ", serviceName,
+        NAMING_LOGGER.info("[GRPC-SUBSCRIBE] {} service:{}, group:{}, cluster:{} ", namespaceId,
+            serviceName,
             groupName, clusters);
         redoService.cacheSubscriberForRedo(serviceName, groupName, clusters);
         return doSubscribe(serviceName, groupName, clusters);
@@ -447,7 +448,8 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
     @Override
     public void unsubscribe(String serviceName, String groupName, String clusters)
         throws NacosException {
-        NAMING_LOGGER.info("[GRPC-UNSUBSCRIBE] service:{}, group:{}, cluster:{} ", serviceName,
+        NAMING_LOGGER.info("[GRPC-UNSUBSCRIBE] {} service:{}, group:{}, cluster:{} ", namespaceId,
+            serviceName,
             groupName, clusters);
         redoService.subscriberDeregister(serviceName, groupName, clusters);
         doUnsubscribe(serviceName, groupName, clusters);

--- a/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -154,4 +155,88 @@ class NacosLoggingTest {
             assertNull(adapterField.get(fresh));
         }
     }
+    
+    @Test
+    void testLoadConfigurationRecordsLoadedConfigLocation() throws Exception {
+        resetLastLoadedConfigLocation();
+        instance = NacosLogging.getInstance();
+        Properties properties = new Properties();
+        properties.setProperty("nacos.logging.config", "/tmp/nacos-logback.xml");
+        loggingProperties = new NacosLoggingProperties("default.xml", properties);
+        Field loggingPropertiesField = NacosLogging.class.getDeclaredField("loggingProperties");
+        loggingPropertiesField.setAccessible(true);
+        loggingPropertiesField.set(instance, loggingProperties);
+        Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+        adapterField.setAccessible(true);
+        NacosLoggingAdapter cachedLogging = (NacosLoggingAdapter) adapterField.get(instance);
+        try {
+            adapterField.set(instance, loggingAdapter);
+            instance.loadConfiguration();
+            Field lastLocationField =
+                NacosLogging.class.getDeclaredField("lastLoadedConfigLocation");
+            lastLocationField.setAccessible(true);
+            assertEquals("/tmp/nacos-logback.xml", lastLocationField.get(instance));
+        } finally {
+            adapterField.set(instance, cachedLogging);
+        }
+    }
+    
+    @Test
+    void testLoadConfigurationSkipsRecordingWhenLocationNull() throws Exception {
+        resetLastLoadedConfigLocation();
+        instance = NacosLogging.getInstance();
+        Properties properties = new Properties();
+        properties.setProperty("nacos.logging.default.config.enabled", "false");
+        loggingProperties = new NacosLoggingProperties(null, properties);
+        Field loggingPropertiesField = NacosLogging.class.getDeclaredField("loggingProperties");
+        loggingPropertiesField.setAccessible(true);
+        loggingPropertiesField.set(instance, loggingProperties);
+        Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+        adapterField.setAccessible(true);
+        NacosLoggingAdapter cachedLogging = (NacosLoggingAdapter) adapterField.get(instance);
+        try {
+            adapterField.set(instance, loggingAdapter);
+            instance.loadConfiguration();
+            Field lastLocationField =
+                NacosLogging.class.getDeclaredField("lastLoadedConfigLocation");
+            lastLocationField.setAccessible(true);
+            assertNull(lastLocationField.get(instance));
+        } finally {
+            adapterField.set(instance, cachedLogging);
+        }
+    }
+    
+    @Test
+    void testLoadConfigurationKeepsFirstLocationWhenUnchanged() throws Exception {
+        resetLastLoadedConfigLocation();
+        instance = NacosLogging.getInstance();
+        Properties properties = new Properties();
+        properties.setProperty("nacos.logging.config", "/tmp/nacos-logback.xml");
+        loggingProperties = new NacosLoggingProperties("default.xml", properties);
+        Field loggingPropertiesField = NacosLogging.class.getDeclaredField("loggingProperties");
+        loggingPropertiesField.setAccessible(true);
+        loggingPropertiesField.set(instance, loggingProperties);
+        Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+        adapterField.setAccessible(true);
+        NacosLoggingAdapter cachedLogging = (NacosLoggingAdapter) adapterField.get(instance);
+        try {
+            adapterField.set(instance, loggingAdapter);
+            instance.loadConfiguration();
+            instance.loadConfiguration();
+            Mockito.verify(loggingAdapter, Mockito.times(2)).loadConfiguration(loggingProperties);
+            Field lastLocationField =
+                NacosLogging.class.getDeclaredField("lastLoadedConfigLocation");
+            lastLocationField.setAccessible(true);
+            assertEquals("/tmp/nacos-logback.xml", lastLocationField.get(instance));
+        } finally {
+            adapterField.set(instance, cachedLogging);
+        }
+    }
+    
+    private void resetLastLoadedConfigLocation() throws Exception {
+        Field lastLocationField = NacosLogging.class.getDeclaredField("lastLoadedConfigLocation");
+        lastLocationField.setAccessible(true);
+        lastLocationField.set(NacosLogging.getInstance(), null);
+    }
+    
 }

--- a/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -228,6 +229,42 @@ class NacosLoggingTest {
                 NacosLogging.class.getDeclaredField("lastLoadedConfigLocation");
             lastLocationField.setAccessible(true);
             assertEquals("/tmp/nacos-logback.xml", lastLocationField.get(instance));
+        } finally {
+            adapterField.set(instance, cachedLogging);
+        }
+    }
+    
+    @Test
+    void testReloadConfigurationIfNeededSkipsWhenAdapterReportsNoChange() throws Exception {
+        instance = NacosLogging.getInstance();
+        Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+        adapterField.setAccessible(true);
+        NacosLoggingAdapter cachedLogging = (NacosLoggingAdapter) adapterField.get(instance);
+        try {
+            when(loggingAdapter.isNeedReloadConfiguration()).thenReturn(false);
+            adapterField.set(instance, loggingAdapter);
+            instance.reloadConfigurationIfNeeded();
+            Mockito.verify(loggingAdapter, Mockito.never()).loadConfiguration(any());
+        } finally {
+            adapterField.set(instance, cachedLogging);
+        }
+    }
+    
+    @Test
+    void testReloadConfigurationIfNeededSurvivesAdapterException() throws Exception {
+        instance = NacosLogging.getInstance();
+        Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+        adapterField.setAccessible(true);
+        NacosLoggingAdapter cachedLogging = (NacosLoggingAdapter) adapterField.get(instance);
+        try {
+            when(loggingAdapter.isNeedReloadConfiguration()).thenReturn(true);
+            doThrow(new RuntimeException("reload failed")).when(loggingAdapter)
+                .loadConfiguration(loggingProperties);
+            adapterField.set(instance, loggingAdapter);
+            // the scheduled task must never throw, otherwise scheduleAtFixedRate cancels further reloads
+            assertDoesNotThrow(() -> instance.reloadConfigurationIfNeeded());
+            assertDoesNotThrow(() -> instance.reloadConfigurationIfNeeded());
+            Mockito.verify(loggingAdapter, Mockito.times(2)).loadConfiguration(loggingProperties);
         } finally {
             adapterField.set(instance, cachedLogging);
         }


### PR DESCRIPTION
## What is the purpose of the change

Follow-up on the direction confirmed in #13690: make the client's actually effective configuration visible in logs, starting with the two clear gaps.

## Brief changelog

- `NacosLogging`: log the resolved logging config location after a successful load (previously silent — only failures emitted a warning). Repeated periodic reloads with an unchanged location are deduplicated, so this adds at most one log line per actual change. The periodic reload task now goes through `loadConfiguration()` so an adapter exception can no longer cancel the scheduled reload.
- `NamingGrpcClientProxy`: `[GRPC-SUBSCRIBE]` / `[GRPC-UNSUBSCRIBE]` now include the `namespaceId` first, consistent with the existing `[REGISTER-SERVICE]` style, so multi-namespace clients can be told apart in naming logs.

Namespace is deliberately not logged per request: request-level logging only occurs on subscribe/register/config-change paths (long-polling rounds do not log), and existing request-level logs already carry identity where useful (`[REGISTER-SERVICE]` carries namespaceId; failover/snapshot paths carry tenant).

## Verifying this change

- `NacosLoggingTest`: 9/9 pass, including new cases for location recording, null-location skip, and unchanged-location deduplication
- `NamingGrpcClientProxyTest`: 36/36 pass (no behavior change, log format only)
- `mvn -pl client -am compile apache-rat:check checkstyle:check spotless:check spotbugs:check -DskipTests` passes

Fixes #13690

* [x] Make sure there is a Github issue filed for the change
* [x] Format the pull request title like `[ISSUE #123] ...`
* [x] Write a pull request description that is detailed enough
* [x] Write necessary unit-test to verify your logic correction
* [x] Run `mvn spotless:apply` and basic checks (`apache-rat:check checkstyle:check spotbugs:check spotless:check`) pass
