### PR TITLE
Harden server disk path validation for v2.x

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskService.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 
 import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
 
@@ -40,6 +42,10 @@ import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
  */
 @SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class ConfigRawDiskService implements ConfigDiskService {
+    
+    private static final String CURRENT_DIRECTORY = ".";
+    
+    private static final String PARENT_DIRECTORY = "..";
     
     private static final String BASE_DIR = File.separator + "data" + File.separator + "config-data";
     
@@ -64,22 +70,12 @@ public class ConfigRawDiskService implements ConfigDiskService {
         try {
             ParamUtils.checkParam(dataId, group, tenant);
         } catch (Exception e) {
-            throw new NacosRuntimeException(NacosException.CLIENT_INVALID_PARAM, "parameter is invalid.");
+            throw invalidParameterException();
         }
-        // fix https://github.com/alibaba/nacos/issues/10067
-        dataId = PathEncoderManager.getInstance().encode(dataId);
-        group = PathEncoderManager.getInstance().encode(group);
-        tenant = PathEncoderManager.getInstance().encode(tenant);
-        File file = null;
         if (StringUtils.isBlank(tenant)) {
-            file = new File(EnvUtil.getNacosHome(), BASE_DIR);
-        } else {
-            file = new File(EnvUtil.getNacosHome(), TENANT_BASE_DIR);
-            file = new File(file, tenant);
+            return resolveTargetFile(BASE_DIR, group, dataId);
         }
-        file = new File(file, group);
-        file = new File(file, dataId);
-        return file;
+        return resolveTargetFile(TENANT_BASE_DIR, tenant, group, dataId);
     }
     
     /**
@@ -90,24 +86,55 @@ public class ConfigRawDiskService implements ConfigDiskService {
             ParamUtils.checkParam(grayName);
             ParamUtils.checkParam(dataId, group, tenant);
         } catch (Exception e) {
-            throw new NacosRuntimeException(NacosException.CLIENT_INVALID_PARAM, "parameter is invalid.");
+            throw invalidParameterException();
         }
-        // fix https://github.com/alibaba/nacos/issues/10067
-        dataId = PathEncoderManager.getInstance().encode(dataId);
-        group = PathEncoderManager.getInstance().encode(group);
-        tenant = PathEncoderManager.getInstance().encode(tenant);
-        
-        File file = null;
         if (StringUtils.isBlank(tenant)) {
-            file = new File(EnvUtil.getNacosHome(), GRAY_DIR);
-        } else {
-            file = new File(EnvUtil.getNacosHome(), TENANT_GRAY_DIR);
-            file = new File(file, tenant);
+            return resolveTargetFile(GRAY_DIR, group, dataId, grayName);
         }
-        file = new File(file, group);
-        file = new File(file, dataId);
-        file = new File(file, grayName);
-        return file;
+        return resolveTargetFile(TENANT_GRAY_DIR, tenant, group, dataId, grayName);
+    }
+    
+    private static File resolveTargetFile(String baseDir, String... pathSegments) {
+        Path current = new File(EnvUtil.getNacosHome(), baseDir).toPath().toAbsolutePath()
+                .normalize();
+        for (String pathSegment : pathSegments) {
+            validatePathSegment(pathSegment);
+            String encodedSegment = PathEncoderManager.getInstance().encode(pathSegment);
+            validateEncodedPathSegment(encodedSegment);
+            try {
+                // Each identity field must add exactly one child without collapsing its parent.
+                Path encodedPath = current.getFileSystem().getPath(encodedSegment);
+                Path target = current.resolve(encodedPath).normalize();
+                if (encodedPath.isAbsolute() || encodedPath.getNameCount() != 1
+                        || !current.equals(target.getParent())) {
+                    throw invalidParameterException();
+                }
+                current = target;
+            } catch (InvalidPathException e) {
+                throw invalidParameterException();
+            }
+        }
+        return current.toFile();
+    }
+    
+    private static void validatePathSegment(String pathSegment) {
+        if (StringUtils.isBlank(pathSegment) || CURRENT_DIRECTORY.equals(pathSegment)
+                || PARENT_DIRECTORY.equals(pathSegment) || !ParamUtils.isValid(pathSegment)) {
+            throw invalidParameterException();
+        }
+    }
+
+    private static void validateEncodedPathSegment(String pathSegment) {
+        if (StringUtils.isBlank(pathSegment) || CURRENT_DIRECTORY.equals(pathSegment)
+                || PARENT_DIRECTORY.equals(pathSegment) || pathSegment.indexOf('/') >= 0
+                || pathSegment.indexOf('\\') >= 0 || new File(pathSegment).isAbsolute()) {
+            throw invalidParameterException();
+        }
+    }
+    
+    private static NacosRuntimeException invalidParameterException() {
+        return new NacosRuntimeException(NacosException.CLIENT_INVALID_PARAM,
+                "parameter is invalid.");
     }
     
     /**

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/ParamUtils.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/ParamUtils.java
@@ -31,6 +31,10 @@ import java.util.Map;
  */
 public class ParamUtils {
     
+    private static final String CURRENT_DIRECTORY = ".";
+    
+    private static final String PARENT_DIRECTORY = "..";
+    
     private static char[] validChars = new char[] {'_', '-', '.', ':'};
     
     private static final int TAG_MAX_LEN = 16;
@@ -53,10 +57,10 @@ public class ParamUtils {
     
     /**
      * Whitelist checks that valid parameters can only contain letters, Numbers, and characters in validChars, and
-     * cannot be empty.
+     * cannot be directory control segments.
      */
     public static boolean isValid(String param) {
-        if (param == null) {
+        if (param == null || CURRENT_DIRECTORY.equals(param) || PARENT_DIRECTORY.equals(param)) {
             return false;
         }
         int length = param.length();

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskServiceTest.java
@@ -17,19 +17,31 @@
 package com.alibaba.nacos.config.server.service.dump.disk;
 
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.common.pathencoder.PathEncoderManager;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfigRawDiskServiceTest {
+    
+    @TempDir
+    private File tempDir;
     
     private String cachedOsName;
     
@@ -66,9 +78,109 @@ class ConfigRawDiskServiceTest {
     
     @Test
     void testTargetFileWithInvalidParam() {
-        assertThrows(NacosRuntimeException.class, () -> ConfigRawDiskService.targetFile("../aaa", "testG", "testNS"));
-        assertThrows(NacosRuntimeException.class, () -> ConfigRawDiskService.targetFile("testD", "../aaa", "testNS"));
-        assertThrows(NacosRuntimeException.class, () -> ConfigRawDiskService.targetFile("testD", "testG", "../aaa"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("../aaa", "testG", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("..\\aaa", "testG", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", "../aaa", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", "testG", "../aaa"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile(".", "testG", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", ".", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", "testG", "."));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("..", "testG", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", "..", "testNS"));
+        assertThrows(NacosRuntimeException.class,
+                () -> ConfigRawDiskService.targetFile("testD", "testG", ".."));
+    }
+    
+    @Test
+    void testTargetFileWithUnsafeEncodedParam() {
+        PathEncoderManager pathEncoderManager = Mockito.mock(PathEncoderManager.class);
+        Mockito.when(pathEncoderManager.encode(Mockito.anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        try (MockedStatic<PathEncoderManager> pathEncoderMock = Mockito
+                .mockStatic(PathEncoderManager.class)) {
+            pathEncoderMock.when(PathEncoderManager::getInstance).thenReturn(pathEncoderManager);
+            String[] unsafeEncodedParams = {"", ".", "..", "../target", "..\\target", "\0"};
+            for (String unsafeEncodedParam : unsafeEncodedParams) {
+                Mockito.when(pathEncoderManager.encode("group")).thenReturn(unsafeEncodedParam);
+                assertThrows(NacosRuntimeException.class,
+                        () -> ConfigRawDiskService.targetFile("dataId", "group", "tenant"));
+            }
+        }
+    }
+
+    @Test
+    void testTargetFileAllowsSafeEncodedParam() {
+        PathEncoderManager pathEncoderManager = Mockito.mock(PathEncoderManager.class);
+        Mockito.when(pathEncoderManager.encode(Mockito.anyString()))
+                .thenAnswer(invocation -> "tenant".equals(invocation.getArgument(0))
+                        ? "tenant%A5%encoded" : invocation.getArgument(0));
+        try (MockedStatic<PathEncoderManager> pathEncoderMock = Mockito
+                .mockStatic(PathEncoderManager.class)) {
+            pathEncoderMock.when(PathEncoderManager::getInstance).thenReturn(pathEncoderManager);
+            File target = ConfigRawDiskService.targetFile("dataId", "group", "tenant");
+            assertEquals("tenant%A5%encoded", target.getParentFile().getParentFile().getName());
+        }
+    }
+    
+    @Test
+    void testRemoveConfigInfoRejectsParentDirectoryTraversal() throws IOException {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class)) {
+            envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+            File marker = new File(tempDir, "marker");
+            FileUtils.writeStringToFile(marker, "marker", "UTF-8");
+            ConfigRawDiskService service = new ConfigRawDiskService();
+            assertThrows(NacosRuntimeException.class,
+                    () -> service.removeConfigInfo("..", "..", ""));
+            assertTrue(marker.isFile());
+        }
+    }
+    
+    @Test
+    void testSafeDiskOperationsRemainCompatible() throws IOException {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class)) {
+            envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+            ConfigRawDiskService service = new ConfigRawDiskService();
+            service.saveToDisk("application.properties", "group.v1", "tenant.v1", "content");
+            assertEquals("content",
+                    service.getContent("application.properties", "group.v1", "tenant.v1"));
+            service.removeConfigInfo("application.properties", "group.v1", "tenant.v1");
+            assertNull(service.getContent("application.properties", "group.v1", "tenant.v1"));
+
+            service.saveToDisk("default.properties", "default.group", "", "default content");
+            assertEquals("default content",
+                    service.getContent("default.properties", "default.group", ""));
+            service.removeConfigInfo("default.properties", "default.group", "");
+            assertNull(service.getContent("default.properties", "default.group", ""));
+            
+            service.saveGrayToDisk("application.properties", "group.v1", "tenant.v1", "gray.v1",
+                    "gray content");
+            assertEquals("gray content",
+                    service.getGrayContent("application.properties", "group.v1", "tenant.v1",
+                            "gray.v1"));
+            service.removeConfigInfo4Gray("application.properties", "group.v1", "tenant.v1",
+                    "gray.v1");
+            assertNull(service.getGrayContent("application.properties", "group.v1", "tenant.v1",
+                    "gray.v1"));
+
+            service.saveGrayToDisk("default.properties", "default.group", "", "default.gray",
+                    "default gray content");
+            assertEquals("default gray content",
+                    service.getGrayContent("default.properties", "default.group", "",
+                            "default.gray"));
+            service.removeConfigInfo4Gray("default.properties", "default.group", "",
+                    "default.gray");
+            assertNull(service.getGrayContent("default.properties", "default.group", "",
+                    "default.gray"));
+        }
     }
     
     /**
@@ -96,6 +208,24 @@ class ConfigRawDiskServiceTest {
         String lastSegment = path.getFileName().toString();
         assertEquals(isWindows() ? "aaaa-dsaknkf" : lastSegment, "graynem4567");
         
+    }
+    
+    @Test
+    void testTargetGrayFileWithInvalidParam() throws Exception {
+        Method method = ConfigRawDiskService.class.getDeclaredMethod("targetGrayFile", String.class,
+                String.class, String.class, String.class);
+        method.setAccessible(true);
+        assertInvalidTargetGrayFile(method, "dataId", "group", "tenant", "");
+        assertInvalidTargetGrayFile(method, "dataId", "group", "tenant", ".");
+        assertInvalidTargetGrayFile(method, "dataId", "group", "tenant", "..");
+        assertInvalidTargetGrayFile(method, "dataId", "..", "tenant", "gray");
+    }
+    
+    private void assertInvalidTargetGrayFile(Method method, String dataId, String group,
+            String tenant, String grayName) {
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> method.invoke(null, dataId, group, tenant, grayName));
+        assertTrue(exception.getCause() instanceof NacosRuntimeException);
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/ParamUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/ParamUtilsTest.java
@@ -37,6 +37,8 @@ class ParamUtilsTest {
         assertTrue(ParamUtils.isValid("test"));
         assertTrue(ParamUtils.isValid("test1234"));
         assertTrue(ParamUtils.isValid("test_-.:"));
+        assertFalse(ParamUtils.isValid("."));
+        assertFalse(ParamUtils.isValid(".."));
         assertFalse(ParamUtils.isValid("test!"));
         assertFalse(ParamUtils.isValid("test~"));
     }

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/rule/storage/LocalDiskRuleStorage.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/rule/storage/LocalDiskRuleStorage.java
@@ -24,6 +24,9 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * local disk storage.
@@ -90,14 +93,13 @@ public class LocalDiskRuleStorage implements RuleStorage {
     
     @Override
     public void saveTpsRule(String pointName, String ruleContent) throws IOException {
-        File file = checkTpsBaseDir();
-        File tpsFile = new File(file, pointName);
-        if (!tpsFile.exists()) {
-            tpsFile.createNewFile();
-        }
+        File tpsFile = resolveTpsRuleFile(pointName);
         if (ruleContent == null) {
             DiskUtils.deleteQuietly(tpsFile);
         } else {
+            if (!tpsFile.exists()) {
+                tpsFile.createNewFile();
+            }
             DiskUtils.writeFile(tpsFile, ruleContent.getBytes(Constants.ENCODE), false);
             LOGGER.info("Save tps rule to local,pointName={}, ruleContent ={} ", pointName, ruleContent);
             
@@ -107,11 +109,34 @@ public class LocalDiskRuleStorage implements RuleStorage {
     
     @Override
     public String getTpsRule(String pointName) {
-        File file = checkTpsBaseDir();
-        File tpsFile = new File(file, pointName);
+        File tpsFile = resolveTpsRuleFile(pointName);
         if (!tpsFile.exists()) {
             return null;
         }
         return DiskUtils.readFile(tpsFile);
+    }
+    
+    private File resolveTpsRuleFile(String pointName) {
+        if (pointName == null || pointName.trim().isEmpty() || ".".equals(pointName)
+                || "..".equals(pointName) || pointName.indexOf('/') >= 0
+                || pointName.indexOf('\\') >= 0) {
+            throw invalidPointNameException();
+        }
+        try {
+            Path pointPath = Paths.get(pointName);
+            Path basePath = checkTpsBaseDir().toPath().toAbsolutePath().normalize();
+            Path targetPath = basePath.resolve(pointPath).normalize();
+            if (pointPath.isAbsolute() || pointPath.getNameCount() != 1
+                    || !basePath.equals(targetPath.getParent())) {
+                throw invalidPointNameException();
+            }
+            return targetPath.toFile();
+        } catch (InvalidPathException e) {
+            throw invalidPointNameException();
+        }
+    }
+    
+    private static IllegalArgumentException invalidPointNameException() {
+        return new IllegalArgumentException("pointName must be a direct child file name");
     }
 }

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/rule/storage/LocalDiskRuleStorageTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/rule/storage/LocalDiskRuleStorageTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.rule.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalDiskRuleStorageTest {
+    
+    @TempDir
+    private Path tempDir;
+    
+    private LocalDiskRuleStorage storage;
+    
+    @BeforeEach
+    void setUp() {
+        storage = new LocalDiskRuleStorage();
+        storage.setLocalRuleBaseDir(tempDir.toString());
+    }
+    
+    @Test
+    void testSaveReadAndDeleteTpsRule() throws IOException {
+        String content = "{\"pointName\":\"Config..Query\"}";
+        storage.saveTpsRule("Config..Query", content);
+        assertEquals(content, storage.getTpsRule("Config..Query"));
+        storage.saveTpsRule("Config..Query", null);
+        assertNull(storage.getTpsRule("Config..Query"));
+    }
+    
+    @Test
+    void testRejectsUnsafePointName() {
+        String[] unsafeNames = {null, "", " ", ".", "..", "../outside", "nested/rule",
+                "nested\\rule", "/absolute", "a\0b"};
+        for (String pointName : unsafeNames) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> storage.saveTpsRule(pointName, "rule"));
+            assertThrows(IllegalArgumentException.class, () -> storage.getTpsRule(pointName));
+        }
+    }
+    
+    @Test
+    void testDirectoryControlPointNamesCannotDeleteParentDirectories() throws IOException {
+        Path tpsMarker = tempDir.resolve("data").resolve("tps").resolve("marker");
+        Path dataMarker = tempDir.resolve("data").resolve("marker");
+        Files.createDirectories(tpsMarker.getParent());
+        Files.write(tpsMarker, "tps".getBytes(StandardCharsets.UTF_8));
+        Files.write(dataMarker, "data".getBytes(StandardCharsets.UTF_8));
+        assertThrows(IllegalArgumentException.class, () -> storage.saveTpsRule(".", null));
+        assertThrows(IllegalArgumentException.class, () -> storage.saveTpsRule("..", null));
+        assertTrue(Files.isRegularFile(tpsMarker));
+        assertTrue(Files.isRegularFile(dataMarker));
+    }
+}

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
@@ -40,6 +40,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -455,6 +456,7 @@ public final class DiskUtils {
      */
     public static void decompress(final String sourceFile, final String outputDir, final Checksum checksum)
             throws IOException {
+        final Path outputPath = Paths.get(outputDir).toAbsolutePath().normalize();
         try (final FileInputStream fis = new FileInputStream(sourceFile);
                 final CheckedInputStream cis = new CheckedInputStream(fis, checksum);
                 final ZipInputStream zis = new ZipInputStream(new BufferedInputStream(cis))) {
@@ -464,7 +466,15 @@ public final class DiskUtils {
                 if (isIllegalFileName(fileName)) {
                     continue;
                 }
-                final File entryFile = new File(Paths.get(outputDir, fileName).toString());
+                final Path entryPath = resolveZipEntry(outputPath, fileName);
+                if (entryPath == null) {
+                    continue;
+                }
+                final File entryFile = entryPath.toFile();
+                if (entry.isDirectory()) {
+                    FileUtils.forceMkdir(entryFile);
+                    continue;
+                }
                 FileUtils.forceMkdir(entryFile.getParentFile());
                 try (final FileOutputStream fos = new FileOutputStream(entryFile);
                         final BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -503,6 +513,28 @@ public final class DiskUtils {
             result = bos.toByteArray();
         }
         return result;
+    }
+    
+    private static Path resolveZipEntry(Path outputPath, String fileName) {
+        if (hasWindowsDrivePrefix(fileName)) {
+            return null;
+        }
+        try {
+            Path relativePath = outputPath.getFileSystem().getPath(fileName);
+            Path targetPath = outputPath.resolve(relativePath).normalize();
+            if (relativePath.isAbsolute() || targetPath.equals(outputPath)
+                    || !targetPath.startsWith(outputPath)) {
+                return null;
+            }
+            return targetPath;
+        } catch (InvalidPathException e) {
+            return null;
+        }
+    }
+    
+    private static boolean hasWindowsDrivePrefix(String fileName) {
+        return fileName.length() > 1 && Character.isLetter(fileName.charAt(0))
+                && fileName.charAt(1) == ':';
     }
     
     /**

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
@@ -24,14 +24,20 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.zip.Adler32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -402,6 +408,40 @@ class DiskUtilsTest {
             });
             assertEquals(3, lineCount.get());
         }
+    }
+    
+    @Test
+    void testDecompressKeepsEntriesInsideOutputDirectory() throws IOException {
+        File zipFile = Files.createTempFile("nacos-sys-safe-zip", ".zip").toFile();
+        zipFile.deleteOnExit();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            writeZipEntry(zipOutputStream, ".", "ignored");
+            writeZipEntry(zipOutputStream, "../outside.txt", "ignored");
+            writeZipEntry(zipOutputStream, "C:/windows-absolute.txt", "ignored");
+            writeZipEntry(zipOutputStream, "invalid\0name", "ignored");
+            zipOutputStream.putNextEntry(new ZipEntry("nested/"));
+            zipOutputStream.closeEntry();
+            writeZipEntry(zipOutputStream, "nested/safe.txt", "safe");
+        }
+        File outputDir = Files.createTempDirectory("nacos-sys-safe-output").toFile();
+        outputDir.deleteOnExit();
+        
+        DiskUtils.decompress(zipFile.getAbsolutePath(), outputDir.getAbsolutePath(), new Adler32());
+        
+        assertFalse(new File(outputDir.getParentFile(), "outside.txt").exists());
+        assertTrue(new File(outputDir, "nested").isDirectory());
+        assertTrue(new File(outputDir, "nested/safe.txt").isFile());
+        try (Stream<Path> paths = Files.walk(outputDir.toPath())) {
+            assertFalse(paths.anyMatch(
+                    path -> "windows-absolute.txt".equals(path.getFileName().toString())));
+        }
+    }
+    
+    private static void writeZipEntry(ZipOutputStream zipOutputStream, String name, String content)
+            throws IOException {
+        zipOutputStream.putNextEntry(new ZipEntry(name));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
     }
     
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Backport the disk path hardening from #15804 to `v2.x-develop` with a smaller,
branch-local implementation. Untrusted Config identities, TPS point names, and
archive entries must not resolve to unintended files or directories.

The existing Config disk layout and `PathEncoder` output remain unchanged.

## Brief changelog

* Reject exact `.` and `..` Config identity segments and validate encoded
  segments as direct children of their intended directory.
* Validate local TPS rule names before read, write, or delete operations.
* Keep ZIP extraction targets inside the requested output directory and handle
  directory entries explicitly.
* Add regression coverage for unsafe paths, delete containment, encoded Windows
  names, existing dotted names, and normal Config/TPS/ZIP operations.

## Verifying this change

* `mvn -pl config -Dtest=ConfigRawDiskServiceTest,ParamUtilsTest test`
  * 14 tests passed.
* `mvn -pl sys,plugin/control -am -Dtest=DiskUtilsTest,LocalDiskRuleStorageTest -Dsurefire.failIfNoSpecifiedTests=false -Dnacos.home=/private/tmp/nacos-v2-disk-path-validation test`
  * 47 tests passed across Sys and Control.
* With JDK 8, `package apache-rat:check findbugs:findbugs -DskipTests` passed for
  `config`, `sys`, and `plugin/control` individually; Checkstyle reported zero
  violations.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] This is the `v2.x-develop` backport of the already merged #15804; no separate public issue is used.
* [x] Each commit has a meaningful subject line and body.
* [x] The pull request description explains what the change does, how, and why.
* [x] Unit tests cover the corrected behavior and compatibility paths.
