### PR TITLE
[ISSUE #15821] Increase embedded Derby connection timeout

### DIFF
--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/DataSourcePoolProperties.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/DataSourcePoolProperties.java
@@ -33,6 +33,8 @@ public class DataSourcePoolProperties {
     
     public static final long DEFAULT_CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(3L);
     
+    public static final long DEFAULT_EMBEDDED_CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(10L);
+    
     public static final long DEFAULT_VALIDATION_TIMEOUT = TimeUnit.SECONDS.toMillis(10L);
     
     public static final long DEFAULT_IDLE_TIMEOUT = TimeUnit.MINUTES.toMillis(10L);
@@ -43,10 +45,10 @@ public class DataSourcePoolProperties {
     
     private final HikariDataSource dataSource;
     
-    private DataSourcePoolProperties() {
+    private DataSourcePoolProperties(long defaultConnectionTimeout) {
         dataSource = new HikariDataSource();
         dataSource.setIdleTimeout(DEFAULT_IDLE_TIMEOUT);
-        dataSource.setConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+        dataSource.setConnectionTimeout(defaultConnectionTimeout);
         dataSource.setValidationTimeout(DEFAULT_VALIDATION_TIMEOUT);
         dataSource.setMaximumPoolSize(DEFAULT_MAX_POOL_SIZE);
         dataSource.setMinimumIdle(DEFAULT_MINIMUM_IDLE);
@@ -62,7 +64,16 @@ public class DataSourcePoolProperties {
     }
     
     static DataSourcePoolProperties build(DatasourceConfigResolver configResolver) {
-        DataSourcePoolProperties result = new DataSourcePoolProperties();
+        return build(configResolver, DEFAULT_CONNECTION_TIMEOUT);
+    }
+    
+    static DataSourcePoolProperties build(Environment environment, long defaultConnectionTimeout) {
+        return build(new DatasourceConfigResolver(environment), defaultConnectionTimeout);
+    }
+    
+    private static DataSourcePoolProperties build(DatasourceConfigResolver configResolver,
+        long defaultConnectionTimeout) {
+        DataSourcePoolProperties result = new DataSourcePoolProperties(defaultConnectionTimeout);
         configResolver.bindPoolConfig(result.getDataSource());
         return result;
     }

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/LocalDataSourceServiceImpl.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/LocalDataSourceServiceImpl.java
@@ -152,7 +152,8 @@ public class LocalDataSourceServiceImpl implements DataSourceService {
     
     private synchronized void initialize(String jdbcUrl) {
         DataSourcePoolProperties poolProperties =
-            DataSourcePoolProperties.build(EnvUtil.getEnvironment());
+            DataSourcePoolProperties.build(EnvUtil.getEnvironment(),
+                DataSourcePoolProperties.DEFAULT_EMBEDDED_CONNECTION_TIMEOUT);
         poolProperties.setDriverClassName(jdbcDriverName);
         poolProperties.setJdbcUrl(jdbcUrl);
         poolProperties.setUsername(userName);

--- a/persistence/src/test/java/com/alibaba/nacos/persistence/DerbyTestUtils.java
+++ b/persistence/src/test/java/com/alibaba/nacos/persistence/DerbyTestUtils.java
@@ -54,7 +54,6 @@ public final class DerbyTestUtils {
     public static MockEnvironment createDerbyTestEnvironment() {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("nacos.persistence.sql.derby.limit.enabled", "false");
-        environment.setProperty("db.pool.config.connection-timeout", "30000");
         environment.setProperty("db.pool.config.minimum-idle", "0");
         environment.setProperty("db.pool.config.maximum-pool-size", "1");
         return environment;

--- a/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/DataSourcePoolPropertiesTest.java
+++ b/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/DataSourcePoolPropertiesTest.java
@@ -78,4 +78,28 @@ class DataSourcePoolPropertiesTest {
         assertEquals(20000L, actual.getConnectionTimeout());
         assertEquals(MAX_POOL_SIZE.intValue(), actual.getMaximumPoolSize());
     }
+    
+    @Test
+    void testBuildWithExternalDefault() {
+        DataSourcePoolProperties poolProperties =
+            DataSourcePoolProperties.build(new MockEnvironment());
+        assertEquals(DataSourcePoolProperties.DEFAULT_CONNECTION_TIMEOUT,
+            poolProperties.getDataSource().getConnectionTimeout());
+    }
+    
+    @Test
+    void testBuildWithEmbeddedDefault() {
+        DataSourcePoolProperties poolProperties = DataSourcePoolProperties.build(
+            new MockEnvironment(), DataSourcePoolProperties.DEFAULT_EMBEDDED_CONNECTION_TIMEOUT);
+        assertEquals(DataSourcePoolProperties.DEFAULT_EMBEDDED_CONNECTION_TIMEOUT,
+            poolProperties.getDataSource().getConnectionTimeout());
+    }
+    
+    @Test
+    void testBuildWithEmbeddedDefaultAndConfigOverride() {
+        DataSourcePoolProperties poolProperties = DataSourcePoolProperties.build(environment,
+            DataSourcePoolProperties.DEFAULT_EMBEDDED_CONNECTION_TIMEOUT);
+        assertEquals(CONNECTION_TIMEOUT.longValue(),
+            poolProperties.getDataSource().getConnectionTimeout());
+    }
 }

--- a/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/LocalDataSourceServiceImplTest.java
+++ b/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/LocalDataSourceServiceImplTest.java
@@ -110,6 +110,8 @@ class LocalDataSourceServiceImplTest {
             assertNotNull(service1.getJdbcTemplate());
             assertNotNull(service1.getTransactionTemplate());
             assertEquals("derby", service1.getDataSourceType());
+            assertEquals(DataSourcePoolProperties.DEFAULT_EMBEDDED_CONNECTION_TIMEOUT,
+                ((HikariDataSource) service1.getDatasource()).getConnectionTimeout());
         } finally {
             EnvUtil.setEnvironment(null);
         }

--- a/specs/en/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/en/plugin/datasource-dialect-plugin-spec.md
@@ -201,7 +201,7 @@ The stable datasource module settings are:
 | `nacos.plugin.datasource.db.url.{index}` | `db.url.{index}` | JDBC URL for every index from `0` to `num - 1`. |
 | `nacos.plugin.datasource.db.user[.{index}]` | `db.user[.{index}]` | Shared or per-index username. A missing index falls back to the shared value or index `0`. |
 | `nacos.plugin.datasource.db.password[.{index}]` | `db.password[.{index}]` | Shared or per-index password, with the same fallback rule as `user`. This value is sensitive. |
-| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` or kebab-case equivalent | Hikari connection timeout in milliseconds; default `3000`. |
+| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` or kebab-case equivalent | Hikari connection timeout in milliseconds; default `3000` for external datasources and `10000` for embedded Derby. |
 | `nacos.plugin.datasource.db.pool.config.validation-timeout` | `db.pool.config.validationTimeout` or kebab-case equivalent | Hikari validation timeout in milliseconds; default `10000`. |
 | `nacos.plugin.datasource.db.pool.config.idle-timeout` | `db.pool.config.idleTimeout` or kebab-case equivalent | Hikari idle timeout in milliseconds; default `600000`. |
 | `nacos.plugin.datasource.db.pool.config.maximum-pool-size` | `db.pool.config.maximumPoolSize` or kebab-case equivalent | Hikari maximum pool size; default `20`. |
@@ -223,6 +223,11 @@ preserves existing Hikari pass-through properties while allowing canonical
 values to override matching legacy values. The supported implementation surface
 is the Hikari JavaBean configuration accepted by the bundled version; only the
 stable subset listed above is a long-term Nacos configuration contract.
+
+When no connection timeout is configured, embedded Derby uses a longer default
+to tolerate local filesystem latency during database creation. An explicit
+canonical or legacy connection timeout overrides the default for the selected
+storage mode.
 
 `nacos.plugin.datasource.log.enabled` remains a separate datasource logging
 switch. The embedded/external persistence mode is also outside dialect-private

--- a/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
@@ -165,7 +165,7 @@ datasource 配置 owner，不能把同一份凭据复制到所有方言。
 | `nacos.plugin.datasource.db.url.{index}` | `db.url.{index}` | 从 `0` 到 `num - 1` 每个 index 的 JDBC URL。 |
 | `nacos.plugin.datasource.db.user[.{index}]` | `db.user[.{index}]` | 共享或按 index 配置的用户名；缺少某个 index 时回退共享值或 index `0`。 |
 | `nacos.plugin.datasource.db.password[.{index}]` | `db.password[.{index}]` | 共享或按 index 配置的密码，回退规则与 `user` 相同；该值属于敏感信息。 |
-| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` 或对应 kebab-case | Hikari 连接超时，单位毫秒，默认 `3000`。 |
+| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` 或对应 kebab-case | Hikari 连接超时，单位毫秒；外部数据源默认 `3000`，嵌入式 Derby 默认 `10000`。 |
 | `nacos.plugin.datasource.db.pool.config.validation-timeout` | `db.pool.config.validationTimeout` 或对应 kebab-case | Hikari 校验超时，单位毫秒，默认 `10000`。 |
 | `nacos.plugin.datasource.db.pool.config.idle-timeout` | `db.pool.config.idleTimeout` 或对应 kebab-case | Hikari 空闲超时，单位毫秒，默认 `600000`。 |
 | `nacos.plugin.datasource.db.pool.config.maximum-pool-size` | `db.pool.config.maximumPoolSize` 或对应 kebab-case | Hikari 最大连接数，默认 `20`。 |
@@ -183,6 +183,9 @@ source。索引项按 index 独立解析，因此迁移期间可以同时使用�
 Hikari datasource，从而保留已有 Hikari 属性透传能力，并让标准值覆盖同名旧值。当前实现可
 接受随附 Hikari 版本提供的 JavaBean 配置面，但只有上表明确列出的稳定子集属于 Nacos 长期
 配置契约。
+
+未配置连接超时时，嵌入式 Derby 使用更长的默认值，以容忍数据库创建期间的本地文件系统延迟。
+显式配置的标准 key 或历史 alias 会覆盖所选存储模式的默认值。
 
 `nacos.plugin.datasource.log.enabled` 仍是独立的数据源日志开关。embedded/external
 persistence 模式同样不属于方言私有配置。负责转换加密数据源凭据的 custom environment


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15821.

When Nacos starts with embedded Derby on a slow disk, creating the initial
Derby connection can exceed the current 3-second Hikari connection timeout.
The timeout interrupts database initialization and can leave an incomplete
Derby directory behind; subsequent startup then reports the secondary
`XBM0A` / missing `service.properties` error.

This change gives embedded Derby a separate 10-second default connection
timeout. The external datasource default remains 3 seconds, so the
fast-failure behavior for external databases is unchanged.

Explicit datasource pool timeout configuration continues to take precedence
over either default.

## Brief changelog

- Add a 10-second default connection timeout for embedded Derby.
- Keep the 3-second default for external datasources.
- Cover external default, embedded Derby default, and explicit configuration
  override behavior with unit tests.
- Update the English and Chinese datasource dialect plugin specifications.

## Verifying this change

- Ran `mvn -pl persistence spotless:apply`
- Ran `mvn -pl persistence spotless:check`
- Ran:

  ```bash
  mvn -pl persistence -am \
    '-Dtest=DataSourcePoolPropertiesTest,LocalDataSourceServiceImplTest' \
    '-Dsurefire.failIfNoSpecifiedTests=false' test